### PR TITLE
Added ability to override the filename and Content-Type

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,4 +83,19 @@ form.submit('example.org/upload', function(err, res) {
 });
 ```
 
+The filename and Content-Type can be overridden
+
+``` javascript
+var FormData = require('form-data');
+var fs = require('fs');
+
+var form = new FormData();
+form.append('my_field', 'my value');
+form.append('my_buffer', new Buffer(10));
+form.append('my_file', fs.createReadStream('/foo/bar.jpg'), {
+  'filename': 'somefilename.csv.gz',
+  'content-type': 'application/x-gzip'
+});
+```
+
 [xhr2-fd]: http://dev.w3.org/2006/webapi/XMLHttpRequest-2/Overview.html#the-formdata-interface

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -20,13 +20,13 @@ util.inherits(FormData, CombinedStream);
 
 FormData.LINE_BREAK = '\r\n';
 
-FormData.prototype.append = function(field, value) {
+FormData.prototype.append = function(field, value, details) {
   var append = CombinedStream.prototype.append.bind(this);
 
   // all that streamy business can't handle numbers
   if (typeof value == 'number') value = ''+value;
 
-  var header = this._multiPartHeader(field, value);
+  var header = this._multiPartHeader(field, value, details);
   var footer = this._multiPartFooter(field, value);
 
   append(header);
@@ -87,15 +87,21 @@ FormData.prototype._trackLength = function(header, value) {
   });
 };
 
-FormData.prototype._multiPartHeader = function(field, value) {
+FormData.prototype._multiPartHeader = function(field, value, details) {
   var boundary = this.getBoundary();
   var header =
     '--' + boundary + FormData.LINE_BREAK +
     'Content-Disposition: form-data; name="' + field + '"';
 
+  // sometimes you want to set the name and the type
+  if(details && details.filename && details['content-type']) {
+    header +=
+      '; filename="' + details.filename + '"' + FormData.LINE_BREAK +
+      'Content-Type: ' + details['content-type'];
+
   // fs- and request- streams have path property
   // TODO: Use request's response mime-type
-  if (value.path) {
+  } else if (value.path) {
     header +=
       '; filename="' + path.basename(value.path) + '"' + FormData.LINE_BREAK +
       'Content-Type: ' + mime.lookup(value.path);


### PR DESCRIPTION
I hit a case with the mime module, it would set `application/octet-stream` for files with the `.gz` extension. That normally isn't an issue unless your communicating with an API that specifically expects `application/x-gzip`.
