### PR TITLE
Use default port 443 for https requests

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -253,10 +253,11 @@ FormData.prototype.getLength = function(cb) {
 FormData.prototype.submit = function(params, cb) {
 
   var request
+    , isHttps = params.protocol == 'https:'
     , options
     , defaults = {
         method : 'post',
-        port   : 80,
+        port   : isHttps ? 443 : 80,
         headers: this.getHeaders()
     };
 
@@ -277,9 +278,7 @@ FormData.prototype.submit = function(params, cb) {
   }
 
   // https if specified, fallback to http in any other case
-  if (params.protocol == 'https:') {
-    // override default port
-    if (!params.port) options.port = 443;
+  if (isHttps) {
     request = https.request(options);
   } else {
     request = http.request(options);


### PR DESCRIPTION
The submit() method was defaulting HTTPS port to 80 if no port number was given.

This PR sets the correct port!  
