### PR TITLE
Do not assume we can determine content length for generic Readable streams.

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -295,7 +295,8 @@ FormData.prototype.submit = function(params, cb) {
     // TODO: Add chunked encoding when no length (if err)
 
     // add content length
-    request.setHeader('Content-Length', length);
+    if (length)
+      request.setHeader('Content-Length', length);
 
     this.pipe(request);
     if (cb) {

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -6,6 +6,7 @@ var https = require('https');
 var parseUrl = require('url').parse;
 var fs = require('fs');
 var mime = require('mime');
+var Stream = require('stream').Stream;
 var async = require('async');
 
 module.exports = FormData;
@@ -70,42 +71,42 @@ FormData.prototype._trackLength = function(header, value, options) {
     + FormData.LINE_BREAK.length;
 
   // empty or either doesn't have path or not an http response
-  if (!value || ( !value.path && !(value.readable && value.hasOwnProperty('httpVersion')) )) {
+  if (!value || ( !value.path && !(value.readable && value.hasOwnProperty('httpVersion'))  && !(value instanceof Stream))) {
     return;
   }
 
   // no need to bother with the length
   if (!options.knownLength)
-  this._lengthRetrievers.push(function(next) {
+    this._lengthRetrievers.push(function(next) {
 
-    if (value.hasOwnProperty('fd')) {
-      fs.stat(value.path, function(err, stat) {
-        if (err) {
-          next(err);
-          return;
-        }
+      if (value.hasOwnProperty('fd')) {
+        fs.stat(value.path, function(err, stat) {
+          if (err) {
+            next(err);
+            return;
+          }
 
-        next(null, stat.size);
-      });
+          next(null, stat.size);
+        });
 
-    // or http response
-    } else if (value.hasOwnProperty('httpVersion')) {
-      next(null, +value.headers['content-length']);
+      // or http response
+      } else if (value.hasOwnProperty('httpVersion')) {
+        next(null, +value.headers['content-length']);
 
-    // or request stream http://github.com/mikeal/request
-    } else if (value.hasOwnProperty('httpModule')) {
-      // wait till response come back
-      value.on('response', function(response) {
-        value.pause();
-        next(null, +response.headers['content-length']);
-      });
-      value.resume();
+      // or request stream http://github.com/mikeal/request
+      } else if (value.hasOwnProperty('httpModule')) {
+        // wait till response come back
+        value.on('response', function(response) {
+          value.pause();
+          next(null, +response.headers['content-length']);
+        });
+        value.resume();
 
-    // something else
-    } else {
-      next('Unknown stream');
-    }
-  });
+        // something else
+      } else {
+        next('Unknown stream');
+      }
+    });
 };
 
 FormData.prototype._multiPartHeader = function(field, value, options) {

--- a/test/integration/test-form-get-length-sync.js
+++ b/test/integration/test-form-get-length-sync.js
@@ -3,6 +3,7 @@ var assert = common.assert;
 var FormData = require(common.dir.lib + '/form_data');
 var fake = require('fake').create();
 var fs = require('fs');
+var Readable = require('stream').Readable;
 
 (function testGetLengthSync() {
   var fields = [
@@ -73,4 +74,31 @@ var fs = require('fs');
   var calculatedLength = form.getLengthSync();
 
   assert.equal(expectedLength, calculatedLength);
+})();
+
+(function testReadableStreamData() {
+  var form = new FormData();
+  var expectedLength = 0;
+
+  var util = require('util');
+  util.inherits(CustomReadable, Readable);
+
+  function CustomReadable(opt) {
+    Readable.call(this, opt);
+    this._max = 2;
+    this._index = 1;
+  }
+
+  CustomReadable.prototype._read = function() {
+    var i = this._index++;
+    if (i > this._max)
+      this.push(null);
+    else {
+      this.push('' + i);
+    }
+  };
+  form.append('my_txt', new CustomReadable());
+
+  assert.throws(function() { form.getLengthSync(); }, /Cannot calculate proper length in synchronous way/);
+
 })();

--- a/test/integration/test-submit-readable-stream.js
+++ b/test/integration/test-submit-readable-stream.js
@@ -1,0 +1,58 @@
+var common = require('../common');
+var assert = common.assert;
+var http = require('http');
+var path = require('path');
+var mime = require('mime');
+var request = require('request');
+var fs = require('fs');
+var FormData = require(common.dir.lib + '/form_data');
+var IncomingForm = require('formidable').IncomingForm;
+var Readable = require('stream').Readable;
+
+var server = http.createServer(function(req, res) {
+
+  assert.strictEqual(req.headers['Content-Length'], undefined);
+
+  res.writeHead(200);
+  res.end('done');
+});
+
+server.listen(common.port, function() {
+
+  var form = new FormData();
+
+  var util = require('util');
+  util.inherits(CustomReadable, Readable);
+
+  function CustomReadable(opt) {
+    Readable.call(this, opt);
+    this._max = 2;
+    this._index = 1;
+  }
+
+  CustomReadable.prototype._read = function() {
+    var i = this._index++;
+    console.error('send back read data');
+    if (i > this._max)
+      this.push(null);
+    else {
+      this.push('' + i);
+    }
+  };
+  form.append('readable', new CustomReadable());
+
+  form.submit('http://localhost:' + common.port + '/', function(err, res) {
+
+    if (err) {
+      throw err;
+    }
+
+    assert.strictEqual(res.statusCode, 200);
+
+    // unstuck new streams
+    res.resume();
+
+    server.close();
+  });
+
+});


### PR DESCRIPTION
I started using a library which provided me with data as a stream.Readable object. This readable stream did not come from a file (i.e. it was not created using fs.createReadStream(..)). I noticed that the code was incorrectly assuming a certain content-length. I have made fixes to getLength, getLengthSync and submit to make sure that we do not incorrectly assume the content-length for stream data.