### PR TITLE
append: Support chaining

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -45,6 +45,9 @@ FormData.prototype.append = function(field, value, options) {
 
   // pass along options.knownLength
   this._trackLength(header, value, options);
+
+  // Support chaining:
+  return this;
 };
 
 FormData.prototype._trackLength = function(header, value, options) {


### PR DESCRIPTION
I find it nicer to be able to go:

``` javascript
var FormData = require('form-data'),
    form = new FormData().append('foo', 'bar').append('baz', 'quux');
```

than

``` javascript
var FormData = require('form-data'),
    form = new FormData();
form.append('foo', 'bar');
form.append('baz', 'quux');
```
