### PR TITLE
Add content-length to part with knownLength option

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -160,6 +160,12 @@ FormData.prototype._multiPartHeader = function(field, value, options) {
         'Content-Type: ' + value.headers['content-type'];
     }
 
+    // for lazy people like @Jacob-McKay that don't wanna do the custom header thing
+    // but have specified the length of their stream already
+    if (options.knownLength){
+      header += FormData.LINE_BREAK + 'Content-Length: ' + options.knownLength;
+    }
+
     header += FormData.LINE_BREAK + FormData.LINE_BREAK;
   }
 


### PR DESCRIPTION
On my server I'm using multiparty to parse the form that request.js and/or form-data.js sent from the client.  Since the part I'm sending is a stream, I need to know it's length so that I can call some cloud storage api method to store the file up there.

My stuff wasn't working well because multiparty.js checks the content-length header on the part to give you the byteCount for the part.

I'm wondering if it's not too big of a deal to just add that header to the part if the user already supplies the knownLength option for a stream.  Are there any drawbacks to this?  I looked at the workflow for using the "custom header" way with this lib and thought this was a better approach.  Waddaya think?