### PR TITLE
lib: emit error when failing to get length

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -341,6 +341,10 @@ FormData.prototype.submit = function(params, cb) {
 
   // get content length and fire away
   this.getLength(function(err, length) {
+    if (err) {
+      this._error(err);
+      return;
+    }
 
     // TODO: Add chunked encoding when no length (if err)
 


### PR DESCRIPTION
If an error occurs during `getLength` it will be silently ignored. Instead a new error will be hit a few lines down since `length` will be `undefined`. This patch emits the first error instead to give the user a clue as to what went wrong.