### PR TITLE
test FormData is readable Stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "fake": "^0.2.2",
     "far": "^0.0.7",
     "formidable": "^1.0.17",
+    "is-stream": "^1.0.1",
     "pre-commit": "^1.0.10",
     "request": "^2.60.0"
   }

--- a/test/integration/test-pipe.js
+++ b/test/integration/test-pipe.js
@@ -7,6 +7,7 @@ var request = require('request');
 var fs = require('fs');
 var FormData = require(common.dir.lib + '/form_data');
 var IncomingForm = require('formidable').IncomingForm;
+var isStream = require('is-stream');
 
 var remoteFile = 'http://localhost:' + common.staticPort + '/unicycle.jpg';
 
@@ -61,6 +62,8 @@ var server = http.createServer(function(req, res) {
 server.listen(common.port, function() {
 
   var form = new FormData();
+
+  assert.ok(isStream.readable(form));
 
   var field;
   for (var name in FIELDS) {


### PR DESCRIPTION
As example in [Alternative submission methods](https://github.com/form-data/form-data#alternative-submission-methods) says you can use `pipe` method on `FormData` object:

```js
var http = require('http');

var request = http.request({
  method: 'post',
  host: 'example.org',
  path: '/upload',
  headers: form.getHeaders()
});

form.pipe(request);

request.on('response', function(res) {
  console.log(res.statusCode);
});
```

But `FormData` object seems to not be readable Stream. We using [is-stream](http://npmjs.com/is-stream) module for testing, that object is readable stream.