### PR TITLE
A minor change to how field names are encoded

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -37,7 +37,7 @@ function FormData() {
 FormData.LINE_BREAK = '\r\n';
 FormData.DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 
-FormData.prototype.append = function(field, value, options) {
+FormData.prototype.append = function(field, value, options, encodeFieldNamesWithoutQuotes) {
 
   options = options || {};
 
@@ -61,7 +61,7 @@ FormData.prototype.append = function(field, value, options) {
     return;
   }
 
-  var header = this._multiPartHeader(field, value, options);
+  var header = this._multiPartHeader(field, value, options, encodeFieldNamesWithoutQuotes);
   var footer = this._multiPartFooter();
 
   append(header);
@@ -119,7 +119,7 @@ FormData.prototype._trackLength = function(header, value, options) {
           // inclusive, starts with 0
           next(null, value.end + 1 - (value.start ? value.start : 0));
 
-        // not that fast snoopy
+          // not that fast snoopy
         } else {
           // still need to fetch file size from fs
           fs.stat(value.path, function(err, stat) {
@@ -137,11 +137,11 @@ FormData.prototype._trackLength = function(header, value, options) {
           });
         }
 
-      // or http response
+        // or http response
       } else if (value.hasOwnProperty('httpVersion')) {
         next(null, +value.headers['content-length']);
 
-      // or request stream http://github.com/mikeal/request
+        // or request stream http://github.com/mikeal/request
       } else if (value.hasOwnProperty('httpModule')) {
         // wait till response come back
         value.on('response', function(response) {
@@ -150,7 +150,7 @@ FormData.prototype._trackLength = function(header, value, options) {
         });
         value.resume();
 
-      // something else
+        // something else
       } else {
         next('Unknown stream');
       }
@@ -159,7 +159,7 @@ FormData.prototype._trackLength = function(header, value, options) {
 };
 
 // TODO: Use request's response mime-type
-FormData.prototype._multiPartHeader = function(field, value, options) {
+FormData.prototype._multiPartHeader = function(field, value, options,encodeFieldNamesWithoutQuotes) {
   // custom header specified (as string)?
   // it becomes responsible for boundary
   // (e.g. to handle extra CRLFs on .NET servers)
@@ -171,7 +171,12 @@ FormData.prototype._multiPartHeader = function(field, value, options) {
   var contentType = this._getContentType(value, options);
 
   var contents = '';
-  var headers  = {
+  var headers  = encodeFieldNamesWithoutQuotes?{
+    // add custom disposition as third element or keep it two elements if not
+    'Content-Disposition': ['form-data', 'name=' + field].concat(contentDisposition || []),
+    // if no content type. allow it to be empty array
+    'Content-Type': [].concat(contentType || [])
+  }:{
     // add custom disposition as third element or keep it two elements if not
     'Content-Disposition': ['form-data', 'name="' + field + '"'].concat(contentDisposition || []),
     // if no content type. allow it to be empty array
@@ -365,7 +370,7 @@ FormData.prototype.submit = function(params, cb) {
       host: params.hostname
     }, defaults);
 
-  // use custom params
+    // use custom params
   } else {
 
     options = populate(params, defaults);


### PR DESCRIPTION
I recently needed to use an API that couldn't handle the field names being
encoded with quotes. I added an optional parameter to FormData.append,
that can remove the quotes. Others in a similar situation might find it
useful and it can have no side effects on existing code as far as I can
see.