### PR TITLE
Avoid undefined variable reference in older browsers

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,2 +1,2 @@
 /* eslint-env browser */
-module.exports = FormData;
+module.exports = window.FormData;


### PR DESCRIPTION
If this code is run in a  browser that doesn't have a native `FormData` object, it'll fail with "FormData is not defined" error.

I think it'd be better to return `undefined` in this case, so that the user of this module can handle it gracefully later.