### PR TITLE
Allow paths as filenames in multipart/form-data requests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,7 @@
     "no-undef": 2,
     // Use if () { }
     //       ^ space
-    "space-after-keywords": [2, "always"],
+    "keyword-spacing": 2,
     // Use if () { }
     //          ^ space
     "space-before-blocks": [2, "always"],

--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,7 @@
 .travis.yml
 
 Makefile
+appveyor.yml
 sftp-config.json
 
 coverage/

--- a/Readme.md
+++ b/Readme.md
@@ -7,11 +7,13 @@ The API of this library is inspired by the [XMLHttpRequest-2 FormData Interface]
 [xhr2-fd]: http://dev.w3.org/2006/webapi/XMLHttpRequest-2/Overview.html#the-formdata-interface
 [streams2-thing]: http://nodejs.org/api/stream.html#stream_compatibility_with_older_node_versions
 
-[![Build Status](https://img.shields.io/travis/form-data/form-data/master.svg)](https://travis-ci.org/form-data/form-data) [![Coverage Status](https://coveralls.io/repos/form-data/form-data/badge.svg?branch=master&service=github)](https://coveralls.io/github/form-data/form-data?branch=master) [![Dependency Status](https://img.shields.io/david/form-data/form-data.svg)](https://david-dm.org/form-data/form-data)
+[![Linux Build](https://img.shields.io/travis/form-data/form-data/master.svg?label=linux:0.10-5.x)](https://travis-ci.org/form-data/form-data)
+[![Windows Build](https://img.shields.io/appveyor/ci/alexindigo/form-data/master.svg?label=windows:0.10-5.x)](https://ci.appveyor.com/project/alexindigo/form-data)
+[![Coverage Status](https://img.shields.io/coveralls/jekyll/jekyll/master.svg?label=code+coverage)](https://coveralls.io/github/form-data/form-data?branch=master)
 
-<!--
-[![bitHound Overall Score](https://www.bithound.io/github/form-data/form-data/badges/score.svg)](https://www.bithound.io/github/form-data/form-data) [![Codacy Badge](https://img.shields.io/codacy/43ece80331c246179695e41f81eeffe2.svg)](https://www.codacy.com/app/form-data/form-data)
--->
+[![Dependency Status](https://img.shields.io/david/form-data/form-data.svg)](https://david-dm.org/form-data/form-data)
+[![Codacy Badge](https://img.shields.io/codacy/43ece80331c246179695e41f81eeffe2.svg)](https://www.codacy.com/app/form-data/form-data)
+[![bitHound Overall Score](https://www.bithound.io/github/form-data/form-data/badges/score.svg)](https://www.bithound.io/github/form-data/form-data)
 
 ## Install
 

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ The API of this library is inspired by the [XMLHttpRequest-2 FormData Interface]
 
 [![Linux Build](https://img.shields.io/travis/form-data/form-data/master.svg?label=linux:0.10-5.x)](https://travis-ci.org/form-data/form-data)
 [![Windows Build](https://img.shields.io/appveyor/ci/alexindigo/form-data/master.svg?label=windows:0.10-5.x)](https://ci.appveyor.com/project/alexindigo/form-data)
-[![Coverage Status](https://img.shields.io/coveralls/jekyll/jekyll/master.svg?label=code+coverage)](https://coveralls.io/github/form-data/form-data?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/form-data/form-data/master.svg?label=code+coverage)](https://coveralls.io/github/form-data/form-data?branch=master)
 
 [![Dependency Status](https://img.shields.io/david/form-data/form-data.svg)](https://david-dm.org/form-data/form-data)
 [![Codacy Badge](https://img.shields.io/codacy/43ece80331c246179695e41f81eeffe2.svg)](https://www.codacy.com/app/form-data/form-data)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,22 @@
+init:
+  - git config --global core.autocrlf true
 environment:
   matrix:
-    - nodejs_version: '4.2'
-    - nodejs_version: '0.12'
     - nodejs_version: '0.10'
+    - nodejs_version: '0.12'
+    - nodejs_version: '1.0'
+    - nodejs_version: '4.2'
+    - nodejs_version: '5'
+platform:
+  - x86
+  - x64
 install:
-  - ps: Install-Product node :nodejs_version
-  - set CI=true
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm -g install npm@2
+  - set PATH=%APPDATA%\npm;%PATH%
   - npm install
-matrix:
-  fast_finish: true
-build: off
-version: '{build}'
-shallow_clone: true
-clone_depth: 1
 test_script:
+  - node --version
+  - npm --version
   - npm run test
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - nodejs_version: '5'
+    - nodejs_version: '4'
+    - nodejs_version: '0.12'
+    - nodejs_version: '0.10'
+install:
+  - ps: Install-Product node :nodejs_version
+  - set CI=true
+  - npm install
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
+test_script:
+  - npm run test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: '5'
-    - nodejs_version: '4'
+    - nodejs_version: '4.2'
     - nodejs_version: '0.12'
     - nodejs_version: '0.10'
 install:

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,2 +1,2 @@
 /* eslint-env browser */
-module.exports = FormData;
+module.exports = window.FormData;

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -45,7 +45,10 @@ FormData.prototype.append = function(field, value, options) {
   if (typeof options == 'string') {
     options = {filename: options};
   }
-
+  if( !options.hasOwnProperty('basename') ){
+    options.basename = true;
+  }
+  
   var append = CombinedStream.prototype.append.bind(this);
 
   // all that streamy business can't handle numbers
@@ -119,7 +122,7 @@ FormData.prototype._trackLength = function(header, value, options) {
           // inclusive, starts with 0
           next(null, value.end + 1 - (value.start ? value.start : 0));
 
-        // not that fast snoopy
+          // not that fast snoopy
         } else {
           // still need to fetch file size from fs
           fs.stat(value.path, function(err, stat) {
@@ -137,11 +140,11 @@ FormData.prototype._trackLength = function(header, value, options) {
           });
         }
 
-      // or http response
+        // or http response
       } else if (value.hasOwnProperty('httpVersion')) {
         next(null, +value.headers['content-length']);
 
-      // or request stream http://github.com/mikeal/request
+        // or request stream http://github.com/mikeal/request
       } else if (value.hasOwnProperty('httpModule')) {
         // wait till response come back
         value.on('response', function(response) {
@@ -150,7 +153,7 @@ FormData.prototype._trackLength = function(header, value, options) {
         });
         value.resume();
 
-      // something else
+        // something else
       } else {
         next('Unknown stream');
       }
@@ -201,7 +204,7 @@ FormData.prototype._getContentDisposition = function(value, options) {
   }
 
   if (filename) {
-    contentDisposition = 'filename="' + path.basename(filename) + '"';
+    contentDisposition = 'filename="' + ( options.basename ? path.basename(filename) : filename ) + '"';
   }
 
   return contentDisposition;
@@ -365,7 +368,7 @@ FormData.prototype.submit = function(params, cb) {
       host: params.hostname
     }, defaults);
 
-  // use custom params
+    // use custom params
   } else {
 
     options = populate(params, defaults);

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -311,9 +311,9 @@ FormData.prototype.getLengthSync = function() {
     knownLength += this._lastBoundary().length;
   }
 
-  // https://github.com/felixge/node-form-data/issues/40
+  // https://github.com/form-data/form-data/issues/40
   if (this._lengthRetrievers.length) {
-    // Some async length retrivers are present
+    // Some async length retrievers are present
     // therefore synchronous length calculation is false.
     // Please use getLength(callback) to get proper length
     this._error(new Error('Cannot calculate proper length in synchronous way.'));

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -161,7 +161,6 @@ FormData.prototype._trackLength = function(header, value, options) {
   }
 };
 
-// TODO: Use request's response mime-type
 FormData.prototype._multiPartHeader = function(field, value, options) {
   // custom header specified (as string)?
   // it becomes responsible for boundary
@@ -210,8 +209,6 @@ FormData.prototype._getContentDisposition = function(value, options) {
   return contentDisposition;
 };
 
-// TODO: Streamline logic here
-// maybe have content-type always present
 FormData.prototype._getContentType = function(value, options) {
 
   // use custom content-type above all
@@ -394,8 +391,6 @@ FormData.prototype.submit = function(params, cb) {
       this._error(err);
       return;
     }
-
-    // TODO: Add chunked encoding when no length (if err)
 
     // add content length
     request.setHeader('Content-Length', length);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "predebug": "rimraf coverage test/tmp",
     "debug": "verbose=1 ./test/run.js",
     "check": "istanbul check-coverage coverage/coverage*.json",
-    "coverage": "codeclimate-test-reporter < ./coverage/lcov.info; codacy-coverage < ./coverage/lcov.info; true"
+    "coverage": "codacy-coverage < ./coverage/lcov.info; true"
   },
   "pre-commit": [
     "lint",
@@ -35,7 +35,6 @@
   "license": "MIT",
   "devDependencies": {
     "codacy-coverage": "^1.1.3",
-    "codeclimate-test-reporter": "^0.1.1",
     "coveralls": "^2.11.6",
     "eslint": "^1.10.3",
     "fake": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "istanbul": "^0.4.1",
     "pre-commit": "^1.0.10",
     "request": "^2.60.0",
-    "rimraf": "^2.5.0"
+    "rimraf": "^2.5.0",
+    "win-spawn": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "codacy-coverage": "^1.1.3",
     "coveralls": "^2.11.6",
+    "cross-spawn": "^2.1.5",
     "eslint": "^1.10.3",
     "fake": "^0.2.2",
     "far": "^0.0.7",
@@ -43,7 +44,6 @@
     "istanbul": "^0.4.1",
     "pre-commit": "^1.0.10",
     "request": "^2.60.0",
-    "rimraf": "^2.5.0",
-    "win-spawn": "^2.0.0"
+    "rimraf": "^2.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "async": "^1.4.0",
+    "async": "^1.5.2",
     "combined-stream": "^1.0.5",
-    "mime-types": "^2.1.3"
+    "mime-types": "^2.1.10"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "name": "form-data",
   "description": "A library to create readable \"multipart/form-data\" streams. Can be used to submit forms and file uploads to other web applications.",
-  "version": "1.0.0-rc3",
+  "version": "1.0.0-rc4",
   "repository": {
     "type": "git",
     "url": "git://github.com/form-data/form-data.git"
@@ -35,15 +35,15 @@
   "license": "MIT",
   "devDependencies": {
     "codacy-coverage": "^1.1.3",
-    "coveralls": "^2.11.6",
+    "coveralls": "^2.11.8",
     "cross-spawn": "^2.1.5",
-    "eslint": "^1.10.3",
+    "eslint": "^2.4.0",
     "fake": "^0.2.2",
     "far": "^0.0.7",
     "formidable": "^1.0.17",
-    "istanbul": "^0.4.1",
-    "pre-commit": "^1.0.10",
-    "request": "^2.60.0",
-    "rimraf": "^2.5.0"
+    "istanbul": "^0.4.2",
+    "pre-commit": "^1.1.2",
+    "request": "^2.69.0",
+    "rimraf": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "browser": "./lib/browser",
   "scripts": {
     "pretest": "rimraf coverage test/tmp",
-    "test": "istanbul cover --report none test/run.js && istanbul report",
+    "test": "istanbul cover --report none test/run.js",
+    "posttest": "istanbul report",
     "lint": "eslint lib/*.js test/*.js test/**/*.js",
     "predebug": "rimraf coverage test/tmp",
     "debug": "verbose=1 ./test/run.js",

--- a/test/common.js
+++ b/test/common.js
@@ -48,6 +48,16 @@ common.actions.submit = function(form, server)
   });
 };
 
+common.actions.basicFormOnField = function(name, value) {
+  assert.strictEqual(name, 'my_field');
+  assert.strictEqual(value, 'my_value');
+};
+
+common.actions.formOnField = function(FIELDS, name, value) {
+  assert.ok(name in FIELDS);
+  var field = FIELDS[name];
+  assert.strictEqual(value, field.value + '');
+};
 
 common.actions.formOnFile = function(FIELDS, name, file) {
   assert.ok(name in FIELDS);

--- a/test/common.js
+++ b/test/common.js
@@ -1,5 +1,7 @@
 var fs = require('fs');
 var path = require('path');
+var assert = require('assert');
+var fake = require('fake');
 
 var common = module.exports;
 
@@ -10,8 +12,10 @@ common.dir = {
   tmp: path.join(rootDir, '/test/tmp')
 };
 
-common.assert = require('assert');
-common.fake = require('fake');
+common.defaultTypeValue = function() { return new Buffer([1, 2, 3]); };
+
+common.assert = assert;
+common.fake = fake;
 
 common.port = 8432;
 
@@ -21,3 +25,39 @@ common.httpsPort = 9443;
 // store server cert in common for later reuse, because self-signed
 common.httpsServerKey = fs.readFileSync(path.join(__dirname, './fixture/key.pem'));
 common.httpsServerCert = fs.readFileSync(path.join(__dirname, './fixture/cert.pem'));
+
+// Actions
+
+common.actions = {};
+
+// generic form submit
+common.actions.submit = function(form, server)
+{
+  return form.submit('http://localhost:' + common.port + '/', function(err, res) {
+
+    if (err) {
+      throw err;
+    }
+
+    assert.strictEqual(res.statusCode, 200);
+
+    // unstuck new streams
+    res.resume();
+
+    server.close();
+  });
+};
+
+
+common.actions.formOnFile = function(FIELDS, name, file) {
+  assert.ok(name in FIELDS);
+  var field = FIELDS[name];
+  assert.strictEqual(file.name, path.basename(field.value.path));
+  assert.strictEqual(file.type, field.type);
+};
+
+// after form has finished parsing
+common.actions.formOnEnd = function(res) {
+  res.writeHead(200);
+  res.end('done');
+};

--- a/test/integration/test-custom-content-type.js
+++ b/test/integration/test-custom-content-type.js
@@ -7,7 +7,6 @@ var FormData = require(common.dir.lib + '/form_data');
 
 // wrap non simple values into function
 // just to deal with ReadStream "autostart"
-// Can't wait for 0.10
 var FIELDS = {
   'no_type': {
     value: 'my_value'
@@ -82,23 +81,6 @@ server.listen(common.port, function() {
 
   // custom params object passed to submit
   common.actions.submit(form, server);
-  // form.submit({
-  //   port: common.port,
-  //   path: '/'
-  // }, function(err, res) {
-  //
-  //   if (err) {
-  //     throw err;
-  //   }
-  //
-  //   assert.strictEqual(res.statusCode, 200);
-  //
-  //   // unstuck new streams
-  //   res.resume();
-  //
-  //   server.close();
-  // });
-
 });
 
 process.on('exit', function() {

--- a/test/integration/test-custom-content-type.js
+++ b/test/integration/test-custom-content-type.js
@@ -21,7 +21,7 @@ var FIELDS = {
   },
   'default_type': {
     expectedType: FormData.DEFAULT_CONTENT_TYPE,
-    value: function() { return new Buffer([1, 2, 3]); }
+    value: common.defaultTypeValue
   },
   'implicit_type': {
     expectedType: mime.lookup(common.dir.fixture + '/unicycle.jpg'),
@@ -81,22 +81,23 @@ server.listen(common.port, function() {
   }
 
   // custom params object passed to submit
-  form.submit({
-    port: common.port,
-    path: '/'
-  }, function(err, res) {
-
-    if (err) {
-      throw err;
-    }
-
-    assert.strictEqual(res.statusCode, 200);
-
-    // unstuck new streams
-    res.resume();
-
-    server.close();
-  });
+  common.actions.submit(form, server);
+  // form.submit({
+  //   port: common.port,
+  //   path: '/'
+  // }, function(err, res) {
+  //
+  //   if (err) {
+  //     throw err;
+  //   }
+  //
+  //   assert.strictEqual(res.statusCode, 200);
+  //
+  //   // unstuck new streams
+  //   res.resume();
+  //
+  //   server.close();
+  // });
 
 });
 

--- a/test/integration/test-custom-filename.js
+++ b/test/integration/test-custom-filename.js
@@ -66,17 +66,5 @@ server.listen(common.port, function() {
   // No options or implicit file type from extension.
   form.append('unknown_everything', fs.createReadStream(unknownFile));
 
-  form.submit('http://localhost:' + common.port + '/', function(err, res) {
-    if (err) {
-      throw err;
-    }
-
-    assert.strictEqual(res.statusCode, 200);
-
-    // unstuck new streams
-    res.resume();
-
-    server.close();
-  });
-
+  common.actions.submit(form, server);
 });

--- a/test/integration/test-custom-headers.js
+++ b/test/integration/test-custom-headers.js
@@ -50,17 +50,5 @@ server.listen(common.port, function() {
   // (available to req handler)
   expectedLength = form._lastBoundary().length + form._overheadLength + options.knownLength;
 
-  form.submit('http://localhost:' + common.port + '/', function(err, res) {
-    if (err) {
-      throw err;
-    }
-
-    assert.strictEqual(res.statusCode, 200);
-
-    // unstuck new streams
-    res.resume();
-
-    server.close();
-  });
-
+  common.actions.submit(form, server);
 });

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -2,6 +2,7 @@ var common = require('../common');
 var assert = common.assert;
 var FormData = require(common.dir.lib + '/form_data');
 var fake = require('fake').create();
+var path = require('path');
 var fs = require('fs');
 var http = require('http');
 
@@ -66,8 +67,9 @@ var http = require('http');
 (function testStreamError() {
   var req;
   var form = new FormData();
-  var path = '/why/u/no/exists';
-  var src = fs.createReadStream(path);
+  // make it windows friendly
+  var fakePath = path.resolve('/why/u/no/exists');
+  var src = fs.createReadStream(fakePath);
   var server = http.createServer();
   var addr = 'http://localhost:' + common.port;
 
@@ -75,7 +77,7 @@ var http = require('http');
 
   form.on('error', function(err) {
     assert.equal(err.code, 'ENOENT');
-    assert.equal(err.path, path);
+    assert.equal(err.path, fakePath);
     req.on('error', function() {});
     server.close();
   });

--- a/test/integration/test-http-response.js
+++ b/test/integration/test-http-response.js
@@ -1,8 +1,6 @@
 var common = require('../common');
 var assert = common.assert;
 var http = require('http');
-var path = require('path');
-var mime = require('mime-types');
 var parseUrl = require('url').parse;
 var FormData = require(common.dir.lib + '/form_data');
 var IncomingForm = require('formidable').IncomingForm;
@@ -10,7 +8,6 @@ var IncomingForm = require('formidable').IncomingForm;
 // static server prepared for all tests
 var remoteFile = 'http://localhost:' + common.staticPort + '/unicycle.jpg';
 
-var FIELDS;
 var server;
 
 var parsedUrl = parseUrl(remoteFile);
@@ -21,19 +18,31 @@ var options = {
   host: parsedUrl.hostname
 };
 
+var FIELDS = {
+  'my_field': {
+    value: 'my_value'
+  },
+  'my_buffer': {
+    type: FormData.DEFAULT_CONTENT_TYPE,
+    value: common.defaultTypeValue
+  },
+  'remote_file': {
+    value: 'TBD',
+    name: remoteFile
+  }
+};
+// count total
+var fieldsPassed = Object.keys(FIELDS).length;
+
 // request static file
 http.request(options, function(response) {
 
-  FIELDS = [
-    {name: 'my_field', value: 'my_value'},
-    {name: 'my_buffer', value: new Buffer([1, 2, 3])},
-    {name: 'remote_file', value: response }
-  ];
-
   var form = new FormData();
-  FIELDS.forEach(function(field) {
-    form.append(field.name, field.value);
-  });
+
+  // add http response to the form fields
+  FIELDS['remote_file'].value = response;
+
+  common.actions.populateFields(form, FIELDS);
 
   server.listen(common.port, function() {
     common.actions.submit(form, server);
@@ -48,23 +57,16 @@ server = http.createServer(function(req, res) {
 
   form.parse(req);
 
-  form
-    .on('field', function(name, value) {
-      var field = FIELDS.shift();
-      assert.strictEqual(name, field.name);
-      assert.strictEqual(value, field.value + '');
-    })
-    .on('file', function(name, file) {
-      var field = FIELDS.shift();
-      assert.strictEqual(name, field.name);
-      // http response doesn't have path property
-      assert.strictEqual(file.name, path.basename(field.value.path || remoteFile));
-      assert.strictEqual(file.type, mime.lookup(file.name));
-    })
-    .on('end', common.actions.formOnEnd.bind(null, res));
+  common.actions.checkForm(form, FIELDS, function(fieldsChecked)
+  {
+    // keep track of number of the processed fields
+    fieldsPassed = fieldsPassed - fieldsChecked;
+    // finish it
+    common.actions.formOnEnd(res);
+  });
 });
 
 
 process.on('exit', function() {
-  assert.strictEqual(FIELDS.length, 0);
+  assert.strictEqual(fieldsPassed, 0);
 });

--- a/test/integration/test-http-response.js
+++ b/test/integration/test-http-response.js
@@ -36,18 +36,7 @@ http.request(options, function(response) {
   });
 
   server.listen(common.port, function() {
-
-    form.submit('http://localhost:' + common.port + '/', function(err, res) {
-      if (err) { throw err; }
-
-      assert.strictEqual(res.statusCode, 200);
-
-      // unstuck new streams
-      res.resume();
-
-      server.close();
-    });
-
+    common.actions.submit(form, server);
   });
 
 }).end();
@@ -72,10 +61,7 @@ server = http.createServer(function(req, res) {
       assert.strictEqual(file.name, path.basename(field.value.path || remoteFile));
       assert.strictEqual(file.type, mime.lookup(file.name));
     })
-    .on('end', function() {
-      res.writeHead(200);
-      res.end('done');
-    });
+    .on('end', common.actions.formOnEnd.bind(null, res));
 });
 
 

--- a/test/integration/test-last_boundary-line_break.js
+++ b/test/integration/test-last_boundary-line_break.js
@@ -13,19 +13,7 @@ function submitForm() {
 
   form.append('field', 'value');
 
-  form.submit('http://localhost:' + common.port + '/', function(err, res) {
-
-    if (err) {
-      throw err;
-    }
-
-    assert.strictEqual(res.statusCode, 200);
-
-    // unstuck new streams
-    res.resume();
-
-    server.close();
-  });
+  common.actions.submit(form, server);
 }
 
 // create https server

--- a/test/integration/test-pipe.js
+++ b/test/integration/test-pipe.js
@@ -40,9 +40,7 @@ var server = http.createServer(function(req, res) {
   form
     .on('field', function(name, value) {
       fieldsPassed--;
-      assert.ok(name in FIELDS);
-      var field = FIELDS[name];
-      assert.strictEqual(value, field.value + '');
+      common.actions.formOnField(FIELDS, name, value);
     })
     .on('file', function(name, file) {
       fieldsPassed--;

--- a/test/integration/test-pipe.js
+++ b/test/integration/test-pipe.js
@@ -11,7 +11,6 @@ var remoteFile = 'http://localhost:' + common.staticPort + '/unicycle.jpg';
 
 // wrap non simple values into function
 // just to deal with ReadStream "autostart"
-// Can't wait for 0.10
 var FIELDS = {
   'my_field': {
     value: 'my_value'
@@ -37,16 +36,13 @@ var server = http.createServer(function(req, res) {
 
   form.parse(req);
 
-  form
-    .on('field', function(name, value) {
-      fieldsPassed--;
-      common.actions.formOnField(FIELDS, name, value);
-    })
-    .on('file', function(name, file) {
-      fieldsPassed--;
-      common.actions.formOnFile(FIELDS, name, file);
-    })
-    .on('end', common.actions.formOnEnd.bind(null, res));
+  common.actions.checkForm(form, FIELDS, function(fieldsChecked)
+  {
+    // keep track of number of the processed fields
+    fieldsPassed = fieldsPassed - fieldsChecked;
+    // finish it
+    common.actions.formOnEnd(res);
+  });
 });
 
 server.listen(common.port, function() {

--- a/test/integration/test-pipe.js
+++ b/test/integration/test-pipe.js
@@ -1,7 +1,6 @@
 var common = require('../common');
 var assert = common.assert;
 var http = require('http');
-var path = require('path');
 var mime = require('mime-types');
 var request = require('request');
 var fs = require('fs');
@@ -19,7 +18,7 @@ var FIELDS = {
   },
   'my_buffer': {
     type: FormData.DEFAULT_CONTENT_TYPE,
-    value: function() { return new Buffer([1, 2, 3]); }
+    value: common.defaultTypeValue
   },
   'my_file': {
     type: mime.lookup(common.dir.fixture + '/unicycle.jpg'),
@@ -47,15 +46,9 @@ var server = http.createServer(function(req, res) {
     })
     .on('file', function(name, file) {
       fieldsPassed--;
-      assert.ok(name in FIELDS);
-      var field = FIELDS[name];
-      assert.strictEqual(file.name, path.basename(field.value.path));
-      assert.strictEqual(file.type, field.type);
+      common.actions.formOnFile(FIELDS, name, file);
     })
-    .on('end', function() {
-      res.writeHead(200);
-      res.end('done');
-    });
+    .on('end', common.actions.formOnEnd.bind(null, res));
 });
 
 server.listen(common.port, function() {

--- a/test/integration/test-request.js
+++ b/test/integration/test-request.js
@@ -50,10 +50,7 @@ var server = http.createServer(function(req, res) {
       assert.strictEqual(file.name, path.basename(fileName));
       assert.strictEqual(file.type, mime.lookup(file.name));
     })
-    .on('end', function() {
-      res.writeHead(200);
-      res.end('done');
-    });
+    .on('end', common.actions.formOnEnd.bind(null, res));
 });
 
 server.listen(common.port, function() {

--- a/test/integration/test-return-http-request.js
+++ b/test/integration/test-return-http-request.js
@@ -74,7 +74,7 @@ server.listen(common.port, function() {
     });
   };
 
-  // track progres
+  // track progress
   form.on('progress', function(chunk) {
     progress += chunk.length;
     assert.ok(progress <= expectedLength);

--- a/test/integration/test-submit-custom-header.js
+++ b/test/integration/test-submit-custom-header.js
@@ -41,9 +41,7 @@ var server = http.createServer(function(req, res) {
   form
     .on('field', function(name, value) {
       fieldsPassed--;
-      assert.ok(name in FIELDS);
-      var field = FIELDS[name];
-      assert.strictEqual(value, field.value + '');
+      common.actions.formOnField(FIELDS, name, value);
     })
     .on('file', function(name, file) {
       fieldsPassed--;

--- a/test/integration/test-submit-custom-header.js
+++ b/test/integration/test-submit-custom-header.js
@@ -1,7 +1,6 @@
 var common = require('../common');
 var assert = common.assert;
 var http = require('http');
-var path = require('path');
 var mime = require('mime-types');
 var request = require('request');
 var fs = require('fs');
@@ -19,7 +18,7 @@ var FIELDS = {
   },
   'my_buffer': {
     type: FormData.DEFAULT_CONTENT_TYPE,
-    value: function() { return new Buffer([1, 2, 3]); }
+    value: common.defaultTypeValue
   },
   'my_file': {
     type: mime.lookup(common.dir.fixture + '/unicycle.jpg'),
@@ -48,15 +47,9 @@ var server = http.createServer(function(req, res) {
     })
     .on('file', function(name, file) {
       fieldsPassed--;
-      assert.ok(name in FIELDS);
-      var field = FIELDS[name];
-      assert.strictEqual(file.name, path.basename(field.value.path));
-      assert.strictEqual(file.type, field.type);
+      common.actions.formOnFile(FIELDS, name, file);
     })
-    .on('end', function() {
-      res.writeHead(200);
-      res.end('done');
-    });
+    .on('end', common.actions.formOnEnd.bind(null, res));
 });
 
 server.listen(common.port, function() {
@@ -83,16 +76,12 @@ server.listen(common.port, function() {
       'x-test-header': 'test-header-value'
     }
   }, function(err, res) {
-
-    if (err) {
-      throw err;
-    }
+    if (err) throw err;
 
     assert.strictEqual(res.statusCode, 200);
 
-    // unstuck new streams
+    // unstuck streams
     res.resume();
-
     server.close();
   });
 

--- a/test/integration/test-submit-custom.js
+++ b/test/integration/test-submit-custom.js
@@ -1,7 +1,6 @@
 var common = require('../common');
 var assert = common.assert;
 var http = require('http');
-var path = require('path');
 var mime = require('mime-types');
 var request = require('request');
 var fs = require('fs');
@@ -19,7 +18,7 @@ var FIELDS = {
   },
   'my_buffer': {
     type: FormData.DEFAULT_CONTENT_TYPE,
-    value: function() { return new Buffer([1, 2, 3]); }
+    value: common.defaultTypeValue
   },
   'my_file': {
     type: mime.lookup(common.dir.fixture + '/unicycle.jpg'),
@@ -47,15 +46,9 @@ var server = http.createServer(function(req, res) {
     })
     .on('file', function(name, file) {
       fieldsPassed--;
-      assert.ok(name in FIELDS);
-      var field = FIELDS[name];
-      assert.strictEqual(file.name, path.basename(field.value.path));
-      assert.strictEqual(file.type, field.type);
+      common.actions.formOnFile(FIELDS, name, file);
     })
-    .on('end', function() {
-      res.writeHead(200);
-      res.end('done');
-    });
+    .on('end', common.actions.formOnEnd.bind(null, res));
 });
 
 server.listen(common.port, function() {
@@ -80,15 +73,11 @@ server.listen(common.port, function() {
     path: '/'
   }, function(err, res) {
 
-    if (err) {
-      throw err;
-    }
+    if (err) throw err;
 
     assert.strictEqual(res.statusCode, 200);
 
-    // unstuck new streams
     res.resume();
-
     server.close();
   });
 

--- a/test/integration/test-submit-custom.js
+++ b/test/integration/test-submit-custom.js
@@ -40,9 +40,7 @@ var server = http.createServer(function(req, res) {
   form
     .on('field', function(name, value) {
       fieldsPassed--;
-      assert.ok(name in FIELDS);
-      var field = FIELDS[name];
-      assert.strictEqual(value, field.value + '');
+      common.actions.formOnField(FIELDS, name, value);
     })
     .on('file', function(name, file) {
       fieldsPassed--;

--- a/test/integration/test-submit-custom.js
+++ b/test/integration/test-submit-custom.js
@@ -11,7 +11,6 @@ var remoteFile = 'http://localhost:' + common.staticPort + '/unicycle.jpg';
 
 // wrap non simple values into function
 // just to deal with ReadStream "autostart"
-// Can't wait for 0.10
 var FIELDS = {
   'my_field': {
     value: 'my_value'
@@ -37,33 +36,20 @@ var server = http.createServer(function(req, res) {
 
   form.parse(req);
 
-  form
-    .on('field', function(name, value) {
-      fieldsPassed--;
-      common.actions.formOnField(FIELDS, name, value);
-    })
-    .on('file', function(name, file) {
-      fieldsPassed--;
-      common.actions.formOnFile(FIELDS, name, file);
-    })
-    .on('end', common.actions.formOnEnd.bind(null, res));
+  common.actions.checkForm(form, FIELDS, function(fieldsChecked)
+  {
+    // keep track of number of the processed fields
+    fieldsPassed = fieldsPassed - fieldsChecked;
+    // finish it
+    common.actions.formOnEnd(res);
+  });
 });
 
 server.listen(common.port, function() {
 
   var form = new FormData();
 
-  var field;
-  for (var name in FIELDS) {
-    if (!FIELDS.hasOwnProperty(name)) { continue; }
-
-    field = FIELDS[name];
-    // important to append ReadStreams within the same tick
-    if ((typeof field.value == 'function')) {
-      field.value = field.value();
-    }
-    form.append(name, field.value);
-  }
+  common.actions.populateFields(form, FIELDS);
 
   // custom params object passed to submit
   form.submit({
@@ -71,7 +57,9 @@ server.listen(common.port, function() {
     path: '/'
   }, function(err, res) {
 
-    if (err) throw err;
+    if (err) {
+      throw err;
+    }
 
     assert.strictEqual(res.statusCode, 200);
 

--- a/test/integration/test-submit-multi-nocallback.js
+++ b/test/integration/test-submit-multi-nocallback.js
@@ -15,10 +15,7 @@ var server = http.createServer(function(req, res) {
   form.parse(req);
 
   form
-    .on('field', function(name, value) {
-      assert.strictEqual(name, 'my_field');
-      assert.strictEqual(value, 'my_value');
-    })
+    .on('field', common.actions.basicFormOnField)
     .on('end', function() {
       res.writeHead(200);
       res.end('done');

--- a/test/integration/test-submit-multi.js
+++ b/test/integration/test-submit-multi.js
@@ -41,10 +41,7 @@ server = http.createServer(function(req, res) {
   form.parse(req);
 
   form
-    .on('field', function(name, value) {
-      assert.strictEqual(name, 'my_field');
-      assert.strictEqual(value, 'my_value');
-    })
+    .on('field', common.actions.basicFormOnField)
     .on('end', common.actions.formOnEnd.bind(null, res));
 });
 

--- a/test/integration/test-submit-multi.js
+++ b/test/integration/test-submit-multi.js
@@ -45,10 +45,7 @@ server = http.createServer(function(req, res) {
       assert.strictEqual(name, 'my_field');
       assert.strictEqual(value, 'my_value');
     })
-    .on('end', function() {
-      res.writeHead(200);
-      res.end('done');
-    });
+    .on('end', common.actions.formOnEnd.bind(null, res));
 });
 
 server.listen(common.port, function() {

--- a/test/integration/test-submit.js
+++ b/test/integration/test-submit.js
@@ -39,9 +39,7 @@ var server = http.createServer(function(req, res) {
   form
     .on('field', function(name, value) {
       fieldsPassed--;
-      assert.ok(name in FIELDS);
-      var field = FIELDS[name];
-      assert.strictEqual(value, field.value + '');
+      common.actions.formOnField(FIELDS, name, value);
     })
     .on('file', function(name, file) {
       fieldsPassed--;

--- a/test/integration/test-submit.js
+++ b/test/integration/test-submit.js
@@ -36,33 +36,20 @@ var server = http.createServer(function(req, res) {
 
   form.parse(req);
 
-  form
-    .on('field', function(name, value) {
-      fieldsPassed--;
-      common.actions.formOnField(FIELDS, name, value);
-    })
-    .on('file', function(name, file) {
-      fieldsPassed--;
-      common.actions.formOnFile(FIELDS, name, file);
-    })
-    .on('end', common.actions.formOnEnd.bind(null, res));
+  common.actions.checkForm(form, FIELDS, function(fieldsChecked)
+  {
+    // keep track of number of the processed fields
+    fieldsPassed = fieldsPassed - fieldsChecked;
+    // finish it
+    common.actions.formOnEnd(res);
+  });
 });
 
 server.listen(common.port, function() {
 
   var form = new FormData();
 
-  var field;
-  for (var name in FIELDS) {
-    if (!FIELDS.hasOwnProperty(name)) { continue; }
-
-    field = FIELDS[name];
-    // important to append ReadStreams within the same tick
-    if ((typeof field.value == 'function')) {
-      field.value = field.value();
-    }
-    form.append(name, field.value);
-  }
+  common.actions.populateFields(form, FIELDS);
 
   common.actions.submit(form, server);
 });

--- a/test/run.js
+++ b/test/run.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 var path = require('path');
-var spawn = require('child_process').spawn;
 var static = require('./static');
 var far = require('far').create();
 var farPaths = require('far/lib/paths');
+var spawn = require('win-spawn');
 var basePath = process.cwd();
 var istanbul = path.join(basePath, './node_modules/.bin/istanbul');
 

--- a/test/run.js
+++ b/test/run.js
@@ -3,6 +3,7 @@ var path = require('path');
 var spawn = require('child_process').spawn;
 var static = require('./static');
 var far = require('far').create();
+var farPaths = require('far/lib/paths');
 var basePath = process.cwd();
 var istanbul = path.join(basePath, './node_modules/.bin/istanbul');
 
@@ -48,6 +49,30 @@ if (process.env.running_under_istanbul) {
     }.bind(this));
   };
 }
+
+// augment far to work on windows
+
+farPaths.expandSync = function(pathList) {
+  var expanded = {};
+
+  pathList.forEach(function(p) {
+    p = path.resolve(process.cwd(), p);
+
+    if (!farPaths.isDirectory(p)) {
+      expanded[p] = true;
+      return;
+    }
+
+    farPaths
+      .findRecursiveSync(p)
+      .forEach(function(pp) {
+        expanded[pp] = true;
+      });
+  });
+
+  return Object.keys(expanded);
+};
+
 // continue as normal
 
 if (process.env.verbose) {

--- a/test/run.js
+++ b/test/run.js
@@ -3,7 +3,7 @@ var path = require('path');
 var static = require('./static');
 var far = require('far').create();
 var farPaths = require('far/lib/paths');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var basePath = process.cwd();
 var istanbul = path.join(basePath, './node_modules/.bin/istanbul');
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,36 @@
+# This references the default nodejs container from
+# the Docker Hub: https://registry.hub.docker.com/_/node/
+# If you want Nodesource's container you would reference nodesource/node
+# Read more about containers on our dev center
+# http://devcenter.wercker.com/docs/containers/index.html
+box: node
+# This is the build pipeline. Pipelines are the core of wercker
+# Read more about pipelines on our dev center
+# http://devcenter.wercker.com/docs/pipelines/index.html
+
+# You can also use services such as databases. Read more on our dev center:
+# http://devcenter.wercker.com/docs/services/index.html
+# services:
+    # - postgres
+    # http://devcenter.wercker.com/docs/services/postgresql.html
+
+    # - mongodb
+    # http://devcenter.wercker.com/docs/services/mongodb.html
+build:
+  # The steps that will be executed on build
+  # Steps make up the actions in your pipeline
+  # Read more about steps on our dev center:
+  # http://devcenter.wercker.com/docs/steps/index.html
+  steps:
+    # A step that executes `npm install` command
+    - npm-install
+    # A step that executes `npm test` command
+    - npm-test
+
+    # A custom script step, name value is used in the UI
+    # and the code value contains the command that get executed
+    - script:
+        name: echo nodejs information
+        code: |
+          echo "node version $(node -v) running"
+          echo "npm version $(npm -v) running"


### PR DESCRIPTION
I was trying to use this in conjunction with loopback container service which accepts a path as a filename when connecting to S3.

Long story short, the plugin coerces the filename to the files basename — so I can't send a file path as the name like /path/to/file.png. 

I tried reading through as much of https://www.ietf.org/rfc/rfc2388.txt https://tools.ietf.org/html/rfc2184 as I could and as far as I can tell the only requirements for the filename are that it is US-ASCII. I like how easy your plugin makes it to send file data as multipart/form-data but I would argue it's the application developers job to determine the logic behind properties such as the filename.

I'd hate to break this for others so maybe adding an option to use basename for now would be good?
