### PR TITLE
Add support for relative path for file attachments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -145,6 +145,15 @@ someModule.stream(function(err, stdout, stderr) {
 });
 ```
 
+By default only the basename of the file is included in the form. To include the full path, pass `includePath: true`.
+
+``` javascript
+form.append('file', stream, {
+  filename: 'images/logo.png',
+  includePath: true
+});
+```
+
 For edge cases, like POST request to URL with query string or to pass HTTP auth credentials, object can be passed to `form.submit()` as first parameter:
 
 ``` javascript

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -200,7 +200,8 @@ FormData.prototype._getContentDisposition = function(value, options) {
   }
 
   if (filename) {
-    contentDisposition = 'filename="' + path.basename(filename) + '"';
+    var formFilename = options.includePath ? filename : path.basename(filename);
+    contentDisposition = 'filename="' + formFilename + '"';
   }
 
   return contentDisposition;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "name": "form-data",
   "description": "A library to create readable \"multipart/form-data\" streams. Can be used to submit forms and file uploads to other web applications.",
-  "version": "1.0.0-rc4",
+  "version": "1.0.0-relativepath.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/form-data/form-data.git"

--- a/test/integration/test-custom-filename.js
+++ b/test/integration/test-custom-filename.js
@@ -20,6 +20,10 @@ var options = {
   contentType: 'image/gif'
 };
 
+var optionsWithPath = {
+  filename: 'subdir/test.png',
+};
+
 var server = http.createServer(function(req, res) {
 
   var form = new IncomingForm({uploadDir: common.dir.tmp});
@@ -43,6 +47,9 @@ var server = http.createServer(function(req, res) {
     assert.strictEqual(files['unknown_with_filename_as_object'].name, options.filename, 'Expects custom filename');
     assert.strictEqual(files['unknown_with_filename_as_object'].type, mime.lookup(options.filename), 'Expects filename-derived content-type');
 
+    assert('relative_path' in files);
+    assert.strictEqual(files['relative_path'].name, optionsWithPath.filename, 'Expects filename with relative path');
+
     assert('unknown_everything' in files);
     assert.strictEqual(files['unknown_everything'].type, FormData.DEFAULT_CONTENT_TYPE, 'Expects default content-type');
 
@@ -63,6 +70,8 @@ server.listen(common.port, function() {
   form.append('unknown_with_filename', fs.createReadStream(unknownFile), options.filename);
   // Filename only with unknown file
   form.append('unknown_with_filename_as_object', fs.createReadStream(unknownFile), {filename: options.filename});
+  // Filename with a relative path
+  form.append('relative_path', fs.createReadStream(unknownFile), {filename: optionsWithPath.filename, includePath: true});
   // No options or implicit file type from extension.
   form.append('unknown_everything', fs.createReadStream(unknownFile));
 


### PR DESCRIPTION
I need to be able to provide a relative path in addition to the filename for an attachment.

The change adds an optional option `relativePath` to `append()` to include a path before the file basename in the form multi-part header.

I added a test for the new behavior and a line in the Readme.

This is similar to #181.
