### PR TITLE
Replace async with run-parallel.

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -6,7 +6,7 @@ var https = require('https');
 var parseUrl = require('url').parse;
 var fs = require('fs');
 var mime = require('mime-types');
-var async = require('async');
+var parallel = require('run-parallel');
 var populate = require('./populate.js');
 
 // Public API
@@ -331,7 +331,7 @@ FormData.prototype.getLength = function(cb) {
     return;
   }
 
-  async.parallel(this._lengthRetrievers, function(err, values) {
+  parallel(this._lengthRetrievers, function(err, values) {
     if (err) {
       cb(err);
       return;

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "async": "^1.5.2",
     "combined-stream": "^1.0.5",
-    "mime-types": "^2.1.10"
+    "mime-types": "^2.1.10",
+    "run-parallel": "^1.1.6"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Only `.parallel` was used from `async`, while it is quite a large
dependency, especially in the browser. `run-parallel` has the same api
as `async.parallel` and just brings the needed functionality.