### PR TITLE
Allow form.submit with url string param to use https

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -388,7 +388,8 @@ FormData.prototype.submit = function(params, cb) {
     options = populate({
       port: params.port,
       path: params.pathname,
-      host: params.hostname
+      host: params.hostname,
+      protocol: params.protocol
     }, defaults);
 
   // use custom params

--- a/test/integration/test-submit-url-parsing.js
+++ b/test/integration/test-submit-url-parsing.js
@@ -13,15 +13,21 @@ var form = new FormData();
 form.append('field', 'value');
 
 // Basic parsing
-req = form.submit('http://localhost:' + common.port + '/path', function() {});
+req = form.submit('http://localhost/path', function() {});
 assert.strictEqual(req.path, '/path');
 assert.ok(req.agent instanceof http.Agent, 'req.agent instanceof http.Agent');
+assert.strictEqual(req.getHeader('Host'), 'localhost');
+req.abort();
+
+// Non-default port handling
+req = form.submit('http://localhost:' + common.port, function() {});
 assert.strictEqual(req.getHeader('Host'), 'localhost:' + common.port);
 req.abort();
 
 // HTTPS protocol handling
-req = form.submit('https://localhost:' + common.port + '/path', function() {});
+req = form.submit('https://localhost/path', function() {});
 assert.ok(req.agent instanceof https.Agent, 'req.agent instanceof https.Agent');
+assert.strictEqual(req.getHeader('Host'), 'localhost');
 req.abort();
 
 

--- a/test/integration/test-submit-url-parsing.js
+++ b/test/integration/test-submit-url-parsing.js
@@ -1,0 +1,27 @@
+var http = require('http');
+var https = require('https');
+var common = require('../common');
+var assert = common.assert;
+var FormData = require(common.dir.lib + '/form_data');
+
+/**
+ * Test url parsing during submission
+ */
+
+var req;
+var form = new FormData();
+form.append('field', 'value');
+
+// Basic parsing
+req = form.submit('http://localhost:' + common.port + '/path', function() {});
+assert.strictEqual(req.path, '/path');
+assert.ok(req.agent instanceof http.Agent, 'req.agent instanceof http.Agent');
+assert.strictEqual(req.getHeader('Host'), 'localhost:' + common.port);
+req.abort();
+
+// HTTPS protocol handling
+req = form.submit('https://localhost:' + common.port + '/path', function() {});
+assert.ok(req.agent instanceof https.Agent, 'req.agent instanceof https.Agent');
+req.abort();
+
+


### PR DESCRIPTION
I want to be able to pass a string starting with `https:`  to `form.submit`, and I expect the form to be submitted over https. `url.parse` returns the `protocol` property, however previously it was ignored.

I also added some tests, and would like to hear some comments on them. I had to write them a bit differently from the others, because you can't  pass options for self-signed certs when using string as first parameter to `form.submit`.
