### PR TITLE
Remove async dependency

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -6,7 +6,6 @@ var https = require('https');
 var parseUrl = require('url').parse;
 var fs = require('fs');
 var mime = require('mime-types');
-var async = require('async');
 var populate = require('./populate.js');
 
 // Public API
@@ -357,17 +356,24 @@ FormData.prototype.getLength = function(cb) {
     return;
   }
 
-  async.parallel(this._lengthRetrievers, function(err, values) {
-    if (err) {
-      cb(err);
-      return;
-    }
-
-    values.forEach(function(length) {
+  var left = this._lengthRetrievers.length;
+  this._lengthRetrievers.forEach(function(retriever) {
+    var called = false;
+    retriever(function onLength(err, length) {
+      if (called || left < 0) {
+        return;
+      }
+      called = true;
+      if (err) {
+        left = -1;
+        cb(err);
+        return;
+      }
       knownLength += length;
+      if (--left === 0) {
+        cb(null, knownLength);
+      }
     });
-
-    cb(null, knownLength);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "async": "^2.0.1",
     "combined-stream": "^1.0.5",
     "mime-types": "^2.1.11"
   },


### PR DESCRIPTION
The `async` module currently pulls in `lodash`, which contributes mostly to `async`'s current 5.5MB size. This commit removes the `async` dependency and replaces the single usage with a simple implementation.

This is especially important for dependents like `request`, which are heavily depended upon, so reducing the space used will have a positive effect for all.