### PR TITLE
Update browser.js shim to use self instead of window

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,2 +1,2 @@
 /* eslint-env browser */
-module.exports = window.FormData;
+module.exports = self.FormData;


### PR DESCRIPTION
This allows it to work in web worker environments, helping to fix jsdom's usage of this package there. See https://github.com/tmpvar/jsdom/issues/1592#issuecomment-251094677