### PR TITLE
Fix wrong "main" JavaScript file name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git://github.com/form-data/form-data.git"
   },
-  "main": "./lib/form_data",
+  "main": "./lib/form_data.js",
   "browser": "./lib/browser",
   "scripts": {
     "pretest": "rimraf coverage test/tmp",


### PR DESCRIPTION
`main` file is not ./lib/form_data but ./lib/form_data.js.
This makes error when you use `form-data` in TypeScript code. (See screenshot below)

![Error on import](https://cloud.githubusercontent.com/assets/315601/21886611/f0fd1554-d8ff-11e6-8b7c-de7ffea39894.png)
