### PR TITLE
toString should output '[object FormData]'

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -438,3 +438,7 @@ FormData.prototype._error = function(err) {
     this.emit('error', err);
   }
 };
+
+FormData.prototype.toString = function () {
+  return '[object FormData]';
+};

--- a/test/integration/test-to-string.js
+++ b/test/integration/test-to-string.js
@@ -1,0 +1,5 @@
+var common   = require('../common');
+var assert   = common.assert;
+var FormData = require(common.dir.lib + '/form_data');
+
+assert(new FormData().toString() === '[object FormData]');


### PR DESCRIPTION
`new FormData().toString()` currently outputs `'[object Object]'`, but it should output `'[object FormData]'`.