### PR TITLE
Proper header production

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -186,6 +186,7 @@ FormData.prototype._multiPartHeader = function(field, value, options) {
 
   var header;
   for (var prop in headers) {
+    if (!headers.hasOwnProperty(prop)) continue;
     header = headers[prop];
 
     // skip nullish headers.


### PR DESCRIPTION
the existing code uses a for loop to iterate through headers but does
not check that the values are actually properties, therefore it picks
up methods.  these methods can appear as they are defined within the
Object.prototype and including them in the headers breaks requests as
the stringified methods likely contain carriage returns, which breaks
the request due to malformation of the header

in general, it is better to use Object.keys(headers).forEach() but I
didn’t want to change the style of the code so a call to
.hasOwnProperty() solves the problem