### PR TITLE
Casts anything but buffers and streams to strings on appends.

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -4,6 +4,7 @@ var path = require('path');
 var http = require('http');
 var https = require('https');
 var parseUrl = require('url').parse;
+var Readable = require('stream').Readable;
 var fs = require('fs');
 var mime = require('mime-types');
 var asynckit = require('asynckit');
@@ -46,21 +47,12 @@ FormData.prototype.append = function(field, value, options) {
     options = {filename: options};
   }
 
+  // Convert everything but buffers and streams to strings.
+  if (!value || !(Buffer.isBuffer(value) || value instanceof Readable)) {
+    value = String(value);
+  }
+
   var append = CombinedStream.prototype.append.bind(this);
-
-  // all that streamy business can't handle numbers
-  if (typeof value == 'number') {
-    value = '' + value;
-  }
-
-  // https://github.com/felixge/node-form-data/issues/38
-  if (util.isArray(value)) {
-    // Please convert your array into string
-    // the way web server expects it
-    this._error(new Error('Arrays are not supported.'));
-    return;
-  }
-
   var header = this._multiPartHeader(field, value, options);
   var footer = this._multiPartFooter();
 

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -6,23 +6,6 @@ var path = require('path');
 var fs = require('fs');
 var http = require('http');
 
-// https://github.com/felixge/node-form-data/issues/38
-(function testAppendArray() {
-
-  var form = new FormData();
-
-  var callback = fake.callback('testAppendArray-onError-append');
-  fake.expectAnytime(callback, ['Arrays are not supported.']);
-
-  form.on('error', function(err) {
-    // workaround for expectAnytime handling objects
-    callback(err.message);
-  });
-
-  form.append('my_array', ['bird', 'cute']);
-})();
-
-
 (function testGetLengthSync() {
   var fields = [
     {


### PR DESCRIPTION
This is another browser parity patch and is a breaking 3.x change.
It allows the module to work the same as the browser when it receives unknown types (anything but buffers and streams) and automatically casts them as a string.

Currently there is the open issue https://github.com/form-data/form-data/issues/137 and several similar issues that were closed as duplicates (for things like null, undefined, and objects).