### PR TITLE
Allow newer versions of combined-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "asynckit": "^0.4.0",
-    "combined-stream": "1.0.6",
+    "combined-stream": "^1.0.6",
     "mime-types": "^2.1.12"
   },
   "devDependencies": {


### PR DESCRIPTION
This let's package managers pick up upstream fixes, as with the other dependencies.