### PR TITLE
Cast undefined value to empty string

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -54,6 +54,11 @@ FormData.prototype.append = function(field, value, options) {
 
   var append = CombinedStream.prototype.append.bind(this);
 
+  // cast undefined value to empty string
+  if (typeof value == 'undefined') {
+    value = '';
+  }
+
   // all that streamy business can't handle numbers
   if (typeof value == 'number') {
     value = '' + value;


### PR DESCRIPTION
An undefined value in append will cause a confusing error:
`TypeError: Cannot read property 'name' of undefined`

Typically it's no problem to encode a form with undefined values into a querystring. Using this package to send binary data, one must be careful that all form values are defined.

Simple fix here is casting to empty string

To repro:
```js
var data = {};
var FormData = require('form-data');
var form = new FormData();
form.on('error', console.log);
form.append('woops', data.woops);
```