### PR TITLE
Don't mutate user's input parameters.

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -395,7 +395,6 @@ FormData.prototype.submit = function(params, cb) {
   // parse provided url if it's string
   // or treat it as options object
   if (typeof params == 'string') {
-
     params = parseUrl(params);
     options = populate({
       port: params.port,
@@ -406,8 +405,7 @@ FormData.prototype.submit = function(params, cb) {
 
   // use custom params
   } else {
-
-    options = populate(params, defaults);
+    options = populate(Object.assign({}, params), defaults);
     // if no port provided use default one
     if (!options.port) {
       options.port = options.protocol == 'https:' ? 443 : 80;


### PR DESCRIPTION
If we pass in a `params` to `submit` that we need to reuse across calls to different forms, `populate` in the diff here mutates our input `params`. This causes issues in later calls to `submit` because now our input `params` has a `content-type: multipart/form-data; boundary=---blah123`, and this `blah123` persists across forms incorrectly.