### PR TITLE
chore: move @types/node to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "node": ">= 0.12"
   },
   "dependencies": {
-    "@types/node": "^12.0.8",
     "asynckit": "^0.4.0",
     "combined-stream": "^1.0.6",
     "mime-types": "^2.1.12"
   },
   "devDependencies": {
+    "@types/node": "^12.0.10",
     "browserify": "^13.1.1",
     "browserify-istanbul": "^2.0.0",
     "coveralls": "^2.11.14",


### PR DESCRIPTION
Move `@types/node` from dependencies to devDependencies, according to the discussion of #428 