### PR TITLE
Fix the getHeaders method signatures

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -187,7 +187,7 @@ form.submit({
 ### Methods
 
 - [_Void_ append( **String** _field_, **Mixed** _value_ [, **Mixed** _options_] )](https://github.com/form-data/form-data#void-append-string-field-mixed-value--mixed-options-).
-- [_Array_ getHeaders( [**Array** _userHeaders_] )](https://github.com/form-data/form-data#array-getheaders-array-userheaders-)
+- [_Headers_ getHeaders( [**Headers** _userHeaders_] )](https://github.com/form-data/form-data#array-getheaders-array-userheaders-)
 - [_String_ getBoundary()](https://github.com/form-data/form-data#string-getboundary)
 - [_Buffer_ getBuffer()](https://github.com/form-data/form-data#buffer-getbuffer)
 - [_Integer_ getLengthSync()](https://github.com/form-data/form-data#integer-getlengthsync)
@@ -216,7 +216,7 @@ form.append( 'my_file', fs.createReadStream('/foo/bar.jpg'), 'bar.jpg' );
 form.append( 'my_file', fs.createReadStream('/foo/bar.jpg'), {filename: 'bar.jpg', contentType: 'image/jpeg', knownLength: 19806} );
 ```
 
-#### _Array_ getHeaders( [**Array** _userHeaders_] )
+#### _Headers_ getHeaders( [**Headers** _userHeaders_] )
 This method ads the correct `content-type` header to the provided array of `userHeaders`.  
 
 #### _String_ getBoundary()

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ interface Options {
 declare class FormData extends stream.Readable {
   constructor(options?: Options);
   append(key: string, value: any, options?: FormData.AppendOptions | string): void;
-  getHeaders(userHeaders: FormData.Headers): FormData.Headers;
+  getHeaders(userHeaders?: FormData.Headers): FormData.Headers;
   submit(
     params: string | FormData.SubmitOptions,
     callback?: (error: Error | null, response: http.IncomingMessage) => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export = FormData;
 
 declare class FormData extends stream.Readable {
   append(key: string, value: any, options?: FormData.AppendOptions | string): void;
-  getHeaders(): FormData.Headers;
+  getHeaders(userHeaders: FormData.Headers): FormData.Headers;
   submit(
     params: string | FormData.SubmitOptions,
     callback?: (error: Error | undefined, response: http.IncomingMessage) => void


### PR DESCRIPTION
In the readme, `getHeaders` is described as accepting and returning an array:

```
Array getHeaders( [Array userHeaders] )
```

The function doesn't return an array, and while it can technically accept one, the output it produces doesn't seem useful:

https://github.com/form-data/form-data/blob/905f173a3f785e8d312998e765634ee451ca5f42/lib/form_data.js#L293-L306

Here's how it's defined in [index.d.ds](https://github.com/form-data/form-data/blob/905f173a3f785e8d312998e765634ee451ca5f42/index.d.ts):

https://github.com/form-data/form-data/blob/905f173a3f785e8d312998e765634ee451ca5f42/index.d.ts#L14

https://github.com/form-data/form-data/blob/905f173a3f785e8d312998e765634ee451ca5f42/index.d.ts#L26-L29

This is more correct, but it says that `getHeaders` doesn't take any arguments, which is incorrect.

I've updated the readme to say that it takes and returns `Headers` as defined in `index.d.ts` (but perhaps it should be something more generic like `Object`). I've also updated the type definitions to include the `userHeaders` parameter.

Furthermore, line 300 in `getHeaders` seems redundant:

https://github.com/form-data/form-data/blob/905f173a3f785e8d312998e765634ee451ca5f42/lib/form_data.js#L300

It was [added in ebf47ef](
https://github.com/form-data/form-data/commit/ebf47ef605b6d1e6a730836234a460e080bf79d2#diff-121026c01234c71e2b3b316f7abc5afcR217-R230) because of an issue identified in codacity? / codacy. I'm not sure what problem this could be mitigating.

If it is redundant I'll add another commit to correct it.