### PR TITLE
Fix error in callback signatures

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,11 +14,11 @@ declare class FormData extends stream.Readable {
   getHeaders(): FormData.Headers;
   submit(
     params: string | FormData.SubmitOptions,
-    callback?: (error: Error | undefined, response: http.IncomingMessage) => void
+    callback?: (error: Error | null, response: http.IncomingMessage) => void
   ): http.ClientRequest;
   getBuffer(): Buffer;
   getBoundary(): string;
-  getLength(callback: (err: Error | undefined, length: number) => void): void;
+  getLength(callback: (err: Error | null, length: number) => void): void;
   getLengthSync(): number;
   hasKnownLength(): boolean;
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "pkgfiles": "^2.3.0",
     "pre-commit": "^1.1.3",
     "request": "^2.88.0",
-    "rimraf": "^2.5.4",
+    "rimraf": "^2.7.1",
     "tape": "^4.6.2",
     "typescript": "^3.5.2"
   },


### PR DESCRIPTION
The functions actually give `null` as the error parameter, and not `undefined`.

Without this, `util.promisify` can't be typed correctly on these functions as it expects the callback to receive `Error | null`.