### PR TITLE
form-data: Replaced PhantomJS Dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
   - "10"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "is-node-modern": "^1.0.0",
     "istanbul": "^0.4.5",
     "obake": "^0.1.2",
-    "phantomjs-prebuilt": "^2.1.13",
+    "puppeteer": "^1.19.0",
     "pkgfiles": "^2.3.0",
     "pre-commit": "^1.1.3",
     "request": "^2.88.0",


### PR DESCRIPTION
Phantomjs is an unmaintained project, replaced the phantomjs dependency with the puppeteer.
Updated the travis.yml to remove the nodejs version 4 as mentioned in https://github.com/form-data/form-data/issues/398.