### PR TITLE
Fix constructor options in Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,17 @@ import * as http from 'http';
 
 export = FormData;
 
-interface Options {
+// Extracted because @types/node doesn't export interfaces.
+interface ReadableOptions {
+  highWaterMark?: number;
+  encoding?: string;
+  objectMode?: boolean;
+  read?(this: stream.Readable, size: number): void;
+  destroy?(this: stream.Readable, error: Error | null, callback: (error: Error | null) => void): void;
+  autoDestroy?: boolean;
+}
+
+interface Options extends ReadableOptions {
   writable?: boolean;
   readable?: boolean;
   dataSize?: number;

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -25,7 +25,7 @@ util.inherits(FormData, CombinedStream);
  */
 function FormData(options) {
   if (!(this instanceof FormData)) {
-    return new FormData();
+    return new FormData(options);
   }
 
   this._overheadLength = 0;


### PR DESCRIPTION
Adds definitions for the options of stream.Readable with the options definitions for FormData.
Also passes options through to the constructor if `FormData` is called without new.

Fixes #443 