### PR TITLE
fix memory leak

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -462,8 +462,19 @@ FormData.prototype.submit = function(params, cb) {
 
     this.pipe(request);
     if (cb) {
-      request.on('error', cb);
-      request.on('response', cb.bind(this, null));
+      var onResponse;
+
+      var callback = function (error, responce) {
+        request.removeListener('error', callback);
+        request.removeListener('response', onResponse);
+
+        return cb.call(this, error, responce);
+      };
+
+      onResponse = callback.bind(this, null);
+
+      request.on('error', callback);
+      request.on('response', onResponse);
     }
   }.bind(this));
 


### PR DESCRIPTION
For many reasons, node caches and leaves in memory (for pretty lengthy amount of time) HTTPRequest instances. Form-data doesn't unsubscribe from 'error' and 'response' event, leaving references to finish / callback. This is kind-of okay in most cases (HTTPRequest's do die after a while), it might be a problem with large payloads or other memory-hungry situations.
This was only tested with NodeJS 8 - future versions might change how they are working with HTTPRequest's objects.