### PR TITLE
Note how to defer file descriptor creation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,9 @@ var form = new FormData();
 form.append('my_field', 'my value');
 form.append('my_buffer', new Buffer(10));
 form.append('my_file', fs.createReadStream('/foo/bar.jpg'));
+var streamCtor = (next) => next(fs.createReadStream('/foo/bar.jpg'));
+streamCtor.path = '/foo/bar.jpg'
+form.append('my_deferred_file', streamCtor)
 ```
 
 Also you can use http-response stream:
@@ -214,6 +217,15 @@ form.append( 'my_file', fs.createReadStream('/foo/bar.jpg'), 'bar.jpg' );
 
 // provide an object.
 form.append( 'my_file', fs.createReadStream('/foo/bar.jpg'), {filename: 'bar.jpg', contentType: 'image/jpeg', knownLength: 19806} );
+```
+
+If you need to upload many files and want to defer the creation of a file descriptor until read time, you can pass in a function with the [`next` callback as the first argument](https://github.com/felixge/node-combined-stream#usage).  The function must have the `path` property of the fs.createReadStream, however.
+
+```js
+var streamCtor = (next) => next(fs.createReadStream('/foo/bar.jpg'));
+streamCtor.path = '/foo/bar.jpg'
+
+form.append('my_deferred_file', streamCtor)
 ```
 
 #### _Headers_ getHeaders( [**Headers** _userHeaders_] )


### PR DESCRIPTION
When appending many files and creating readstreams for each one, you run the real risk of blowing you file descriptor limit.  Generally its better to defer the creation of readStreams until you need to read the file.  

Reading into the combined stream docs, it appeared that this would support the `(next) => next(fs.createReadStream('foo')` api, however its not quite that simple.  This module expects a `path` property on the value so I documented that expectation.  

There is probably room for improvement here, API wise, however this should help assist people from having to read too much code to achieve this outcome. 

Thank you for and open to any suggestions.