### PR TITLE
feat: add support for get, getAll, has and set

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -31,6 +31,7 @@ function FormData(options) {
   this._overheadLength = 0;
   this._valueLength = 0;
   this._valuesToMeasure = [];
+  this._entryList = [];
 
   CombinedStream.call(this);
 
@@ -76,6 +77,8 @@ FormData.prototype.append = function(field, value, options) {
 
   // pass along options.knownLength
   this._trackLength(header, value, options);
+
+  this._entryList.push(this._create_entry(field, value));
 };
 
 FormData.prototype._trackLength = function(header, value, options) {
@@ -409,6 +412,44 @@ FormData.prototype.getLength = function(cb) {
     });
 
     cb(null, knownLength);
+  });
+};
+
+FormData.prototype._create_entry = function(field, value) {
+  return { name: field, value: value };
+};
+
+FormData.prototype.set = function(field, value) {
+  const entry = this._create_entry(field, value);
+
+  this._entryList = this._entryList.filter(function(entry) {
+    return entry.name !== field;
+  });
+
+  this._entryList.push(entry);
+};
+
+FormData.prototype.get = function(field) {
+  const foundEntry = this._entryList.find(function(entry) {
+    return entry.name === field;
+  });
+
+  return foundEntry === undefined ? null : foundEntry;
+};
+
+FormData.prototype.getAll = function(field) {
+  return this._entryList
+    .filter(function(entry) {
+      return entry.name === field;
+    })
+    .map(function(entry) {
+      return entry.value;
+    });
+};
+
+FormData.prototype.has = function(field) {
+  return this._entryList.some(function(entry) {
+    return entry.name === field;
   });
 };
 


### PR DESCRIPTION
Following signatures have not been implemented in this PR:

`append(name, blobValue, filename)`
`set(name, blobValue, filename)`

The reason they have not been implemented is to keep the simplicity of first implementation. Those signatures can be added later as additional layer.

To implement this PR I followed the spec at https://xhr.spec.whatwg.org/#create-an-entry.

Let me know if this is something you want inside a library. If I get a green light, I'll implement the tests and in second PR later I'll add the two missing signatures.
