### PR TITLE
fix: add @types/node under peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "combined-stream": "^1.0.8",
     "mime-types": "^2.1.12"
   },
+  "peerDependencies": {
+    "@types/node": "^12.0.10"
+  },
   "devDependencies": {
     "@types/node": "^12.0.10",
     "browserify": "^13.1.1",


### PR DESCRIPTION
This ensures Yarn v2 with Plug'n'Play and TypeScript doesn't complain about form-data missing a dependency on @types/node. See #505. I'm not sure whether or not `^12.0.10` is the correct version to use, but I believe the `peerDependencies` and `devDependencies` versions should match.

Tested as follows with Yarn v2:

```
cd $(mktemp -d)

yarn set version berry

yarn init

yarn add --dev typescript

yarn add form-data@git@github.com:markandrus/form-data.git#head=fix-505 @types/node@^12.0.10

cat >index.ts <<EOF
import FormData = require('form-data')
console.log(FormData)
EOF

yarn run tsc index.ts
```