### PR TITLE
change boundary implementation to hex

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -349,7 +349,7 @@ FormData.prototype._generateBoundary = function() {
   // They are optimized for boyer-moore parsing.
   var boundary = '--------------------------';
   for (var i = 0; i < 24; i++) {
-    boundary += Math.floor(Math.random() * 10).toString(16);
+    boundary += Math.floor(Math.random() * 16).toString(16);
   }
 
   this._boundary = boundary;


### PR DESCRIPTION
The current implementation of the boundary doesn't make sense because we are generating a number between 0-9 and converting it to a string with a radix of 16.

If we want the boundary to be base 10, we should have:
`boundary += Math.floor(Math.random() * 10).toString(10);`

If we want the boundary to be base 16, we should have:
`boundary += Math.floor(Math.random() * 16).toString(16);`

I'd recommend base 16 because it has more entropy and still conforms with the [rfc spec](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1) 