### PR TITLE
fix (npmignore): ignore temporary build files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,6 @@ sftp-config.json
 coverage/
 node_modules/
 test/
+
+yarn.lock
+README.md.bak


### PR DESCRIPTION
Fixes #531 