### PR TITLE
Solve typescript message

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@
 import * as stream from 'stream';
 import * as http from 'http';
 
-export = FormData;
+export default FormData;
 
 // Extracted because @types/node doesn't export interfaces.
 interface ReadableOptions {


### PR DESCRIPTION
solve "This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag."