### PR TITLE
Replace Math Random

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -9,6 +9,7 @@ var Stream = require('stream').Stream;
 var mime = require('mime-types');
 var asynckit = require('asynckit');
 var populate = require('./populate.js');
+var crypto = require('crypto');
 
 // Public API
 module.exports = FormData;
@@ -349,7 +350,7 @@ FormData.prototype._generateBoundary = function() {
   // They are optimized for boyer-moore parsing.
   var boundary = '--------------------------';
   for (var i = 0; i < 24; i++) {
-    boundary += Math.floor(Math.random() * 10).toString(16);
+    boundary += crypto.randomInt(0, 10);
   }
 
   this._boundary = boundary;


### PR DESCRIPTION
In Fortify Scan, Math.random is marked as insecure randomness. So, crypto.randomInt(0, 10) is used.