### PR TITLE
fix: setup toStringTag instead of toString property

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -496,6 +496,9 @@ FormData.prototype._error = function(err) {
   }
 };
 
-FormData.prototype.toString = function () {
-  return '[object FormData]';
-};
+Object.defineProperty(FormData.prototype, Symbol.toStringTag, {
+    value: 'FormData',
+    writable: false,
+    enumerable: false,
+    configurable: true
+});


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag