### PR TITLE
feat: Support Got response stream

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,20 @@ form.append('my_buffer', new Buffer(10));
 form.append('my_logo', request('http://nodejs.org/images/logo.png'));
 ```
 
+Or @sindresorhus's [got](https://github.com/sindresorhus/got) stream:
+
+
+``` javascript
+var FormData = require('form-data');
+var got = require('got');
+
+var form = new FormData();
+
+form.append('my_field', 'my value');
+form.append('my_buffer', new Buffer(10));
+form.append('my_logo', got.stream('http://nodejs.org/images/logo.png'));
+```
+
 In order to submit this form to a web application, call ```submit(url, [callback])``` method:
 
 ``` javascript

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -161,6 +161,9 @@ FormData.prototype._lengthRetriever = function(value, callback) {
     });
     value.resume();
 
+  // got
+  } else if (value.hasOwnProperty('options')) {
+    callback(null, +value.options.headers['content-length']);
   // something else
   } else {
     callback('Unknown stream');

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -162,8 +162,13 @@ FormData.prototype._lengthRetriever = function(value, callback) {
     value.resume();
 
   // got
-  } else if (value.hasOwnProperty('options')) {
-    callback(null, +value.options.headers['content-length']);
+  } else if (value.hasOwnProperty('options') && value.hasOwnProperty('requestUrl')) {
+    const symbolKey = Object.getOwnPropertySymbols(value)
+      .find((symbol) => symbol.toString().includes('originalResponse'));
+    const response = value[symbolKey];
+
+    callback(null, +response.headers['content-length'])
+
   // something else
   } else {
     callback('Unknown stream');


### PR DESCRIPTION
Added Support for @sindresorhus's [got](https://github.com/sindresorhus/got) stream response

With this PR, we can use form-data with got stream response

example.

``` javascript
var FormData = require('form-data');
var got = require('got');

var form = new FormData();

form.append('my_field', 'my value');
form.append('my_buffer', new Buffer(10));
form.append('my_logo', got.stream('http://nodejs.org/images/logo.png'));
```