### PR TITLE
Update form_data.js

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -61,7 +61,7 @@ FormData.prototype.append = function(field, value, options) {
   }
 
   // https://github.com/felixge/node-form-data/issues/38
-  if (util.isArray(value)) {
+  if (Array.isArray(value)) {
     // Please convert your array into string
     // the way web server expects it
     this._error(new Error('Arrays are not supported.'));


### PR DESCRIPTION
## Context
Since [Node v4](https://nodejs.org/en/blog/release/v4.0.0) `util.isArray` has been deprecated. Using `util.isArray` causes:
```bash
(node:12195) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()`
instead.
```
## Fix
Using `Array.isArray` in place of `util.isArray` fixes this issue.