### PR TITLE
Fix node deprecation warning for util.isArray

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -61,7 +61,7 @@ FormData.prototype.append = function(field, value, options) {
   }
 
   // https://github.com/felixge/node-form-data/issues/38
-  if (util.isArray(value)) {
+  if (Array.isArray(value)) {
     // Please convert your array into string
     // the way web server expects it
     this._error(new Error('Arrays are not supported.'));


### PR DESCRIPTION
# Fix Deprecation Warning

* Was receiving a deprecation warning (see below
* Updated `lib/form_data.js` and the warning goes away

Fixes #563 

```
(node:81916) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
    at FormData.append (/coral-api/node_modules/form-data/lib/form_data.js:64:12)
    at EmailService.sendEmail (/coral-api/dist/src/services/email.js:17:22)
    at /coral-api/dist/src/routes/emails.js:15:51
    at Layer.handle [as handle_request] (/coral-api/node_modules/express/lib/router/layer.js:95:5)
    at next (/coral-api/node_modules/express/lib/router/route.js:149:13)
    at Route.dispatch (/coral-api/node_modules/express/lib/router/route.js:119:3)
    at Layer.handle [as handle_request] (/coral-api/node_modules/express/lib/router/layer.js:95:5)
    at /coral-api/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/coral-api/node_modules/express/lib/router/index.js:346:12)
    at next (/coral-api/node_modules/express/lib/router/index.js:280:10)
```