### PR TITLE
[Fix] validate boundary type in `setBoundary()` method

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -302,6 +302,9 @@ FormData.prototype.getHeaders = function (userHeaders) {
 };
 
 FormData.prototype.setBoundary = function (boundary) {
+  if (typeof boundary !== 'string') {
+    throw new TypeError('FormData boundary must be a string');
+  }
   this._boundary = boundary;
 };
 

--- a/test/integration/test-set-boundary.js
+++ b/test/integration/test-set-boundary.js
@@ -24,12 +24,14 @@ var FormData = require(common.dir.lib + '/form_data');
   assert.notEqual(formA.getBoundary(), formB.getBoundary());
 }());
 
-(function testsetBoundaryWithNonString_preExistingBehavior() {
+(function testSetBoundaryWithNonString() {
   var form = new FormData();
 
-  var nonStringValues = [123, { value: 123 }, ['---something']];
-  nonStringValues.forEach(function (value) {
-    form.setBoundary(value);
-    assert.equal(form.getBoundary(), value);
+  var invalidValues = [123, null, undefined, { value: 123 }, ['---something']];
+
+  invalidValues.forEach(function (value) {
+    assert.throws(function () {
+      form.setBoundary(value);
+    }, TypeError);
   });
 }());

--- a/test/integration/test-set-boundary.js
+++ b/test/integration/test-set-boundary.js
@@ -23,3 +23,13 @@ var FormData = require(common.dir.lib + '/form_data');
   assert.equal(formA.getBoundary(), userBoundary);
   assert.notEqual(formA.getBoundary(), formB.getBoundary());
 }());
+
+(function testsetBoundaryWithNonString_preExistingBehavior() {
+  var form = new FormData();
+
+  var nonStringValues = [123, { value: 123 }, ['---something']];
+  nonStringValues.forEach(function (value) {
+    form.setBoundary(value);
+    assert.equal(form.getBoundary(), value);
+  });
+}());


### PR DESCRIPTION
## Summary
This PR adds input validation to the `setBoundar()` method to ensure the boundary is a string. Previously, calling `form.setBoundary()` with a non-string value (like an object number) would silently accept the input, leading to malformed `Content-Type` headers and broken multipart requests.

## Example of the problem (Before Fix)
```js
var form_data = require('form-data');
const form = new form_data();
form.setBoundary({bad: 123});
console.log(form.getHeaders()); 
```
## Output
```shell
{ 'content-type': 'multipart/form-data; boundary=[object Object]' }
```

## Alternate fix:
If throwing an error feels too aggressive or could break existing code relying on loose behavior, I am happy to revise the commit to instead log a warning when a non-string `boundary` is passed to `setBoundary()`. This would still notify developers of potential misuse without disrupting execution.