### PR TITLE
[Deps] update `mime-types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "combined-stream": "^1.0.8",
     "es-set-tostringtag": "^2.1.0",
     "hasown": "^2.0.2",
-    "mime-types": "^2.1.12"
+    "mime-types": "^3.0.1"
   },
   "devDependencies": {
     "@ljharb/eslint-config": "^21.1.1",


### PR DESCRIPTION
Update `mime-types` to support latest transient dependency `mime-db` which includes some newer mime types like `mjs` for `text/javascript`