### PR TITLE
Add sideEffects: false flag, for better tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,6 @@
     "commitLimit": false,
     "backfillLimit": false,
     "hideCredit": true
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Adds `sideEffects: false` to `package.json`. This can enable more tree-shaking, in some cases: https://github.com/webpack/webpack/blob/main/examples/side-effects/README.md

`axios`, which depends on this package, has already added this flag: https://github.com/axios/axios/pull/5025