### PR TITLE
Fix broken repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "4.0.4",
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/form-data/form-data.git"
+    "url": "ssh://github.com/form-data/form-data.git"
   },
   "main": "./lib/form_data",
   "browser": "./lib/browser",


### PR DESCRIPTION
GitHub hasn't supported the git protocol [since 2022](https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git), so this URL is broken.

(This is a common error affecting many popular npm packages; I'm opening PRs on several projects to fix it. I encourage anyone reading this to check any packages they maintain and implement the same fix if appropriate!)