### PR TITLE
Replace status badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@ The API of this library is inspired by the [XMLHttpRequest-2 FormData Interface]
 
 [xhr2-fd]: http://dev.w3.org/2006/webapi/XMLHttpRequest-2/Overview.html#the-formdata-interface
 
-[![Linux Build](https://img.shields.io/travis/form-data/form-data/master.svg?label=linux:6.x-12.x)](https://travis-ci.org/form-data/form-data)
-[![MacOS Build](https://img.shields.io/travis/form-data/form-data/master.svg?label=macos:6.x-12.x)](https://travis-ci.org/form-data/form-data)
-[![Windows Build](https://img.shields.io/travis/form-data/form-data/master.svg?label=windows:6.x-12.x)](https://travis-ci.org/form-data/form-data)
-
-[![Coverage Status](https://img.shields.io/coveralls/form-data/form-data/master.svg?label=code+coverage)](https://coveralls.io/github/form-data/form-data?branch=master)
-[![Dependency Status](https://img.shields.io/david/form-data/form-data.svg)](https://david-dm.org/form-data/form-data)
+[![Tests: node.js < 10](https://github.com/form-data/form-data/actions/workflows/node-aught.yml/badge.svg)](https://github.com/form-data/form-data/actions/workflows/node-aught.yml)
+[![Tests: node.js >= 10](https://github.com/form-data/form-data/actions/workflows/node-tens.yml/badge.svg)](https://github.com/form-data/form-data/actions/workflows/node-tens.yml)
+[![Tests: pretest/posttest](https://github.com/form-data/form-data/actions/workflows/node-pretest.yml/badge.svg)](https://github.com/form-data/form-data/actions/workflows/node-pretest.yml)
 
 ## Install
 


### PR DESCRIPTION
- Closes https://github.com/form-data/form-data/issues/585

## Situation

The [README](https://github.com/form-data/form-data/blob/master/README.md) set of badges display multiple "404 badge not found" data

<img width="1089" height="264" alt="Image" src="https://github.com/user-attachments/assets/1d881de2-657a-4ae0-913e-6027be62505d" />

- https://github.com/form-data/form-data/commit/757b4e32e95726aec9bdcc771fb5a3b564d88034 migrated from Travis to GitHub Actions on Sep 21, 2024

- https://david-dm.org appears to no longer offer the service previously offered.

- https://coveralls.io/github/form-data/form-data?branch=master shows the last run on 15 Feb 2021 for commit 4.0.0

## Change

- Remove non-working / stale badges for
  - https://travis-ci.org/
  - https://david-dm.org/
  - https://coveralls.io/
- Replace with working badges for GitHub Actions workflows

## Reference

- GitHub Actions [Adding a workflow status badge](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge)