### PR TITLE
fix: add RFC 5987 filename* encoding for special characters

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -15,6 +15,51 @@ var setToStringTag = require('es-set-tostringtag');
 var hasOwn = require('hasown');
 var populate = require('./populate.js');
 
+// RFC 5987 Section 3.2.1 defines attr-char as:
+// ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+// Characters outside this set must be percent-encoded in filename* parameter
+// Note: Parentheses () are separators per RFC 2616 Section 2.2 and must be encoded
+var RFC5987_ATTR_CHAR = /[!#$&+\-.^_`|~A-Za-z0-9]/;
+var HEX_RADIX = 16;
+var HEX_PAD_LENGTH = 2;
+
+/**
+ * Percent-encode a filename according to RFC 5987.
+ * Only characters in attr-char are left unencoded.
+ * @param {string} filename - the filename to encode
+ * @returns {string} - the RFC 5987 encoded filename
+ */
+function rfc5987Encode(filename) {
+  var encoded = '';
+  for (var i = 0; i < filename.length; i += 1) {
+    var char = filename[i];
+    if (RFC5987_ATTR_CHAR.test(char)) {
+      encoded += char;
+    } else {
+      // Encode as UTF-8 percent-encoded octets
+      var bytes = Buffer.from(char, 'utf8');
+      for (var j = 0; j < bytes.length; j += 1) {
+        encoded += '%' + bytes[j].toString(HEX_RADIX).toUpperCase().padStart(HEX_PAD_LENGTH, '0');
+      }
+    }
+  }
+  return encoded;
+}
+
+/**
+ * Check if a filename contains characters that need RFC 5987 encoding.
+ * @param {string} filename - the filename to check
+ * @returns {boolean} - true if encoding is needed
+ */
+function needsRfc5987Encoding(filename) {
+  for (var i = 0; i < filename.length; i += 1) {
+    if (!RFC5987_ATTR_CHAR.test(filename[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Create readable "multipart/form-data" streams.
  * Can be used to submit forms
@@ -234,6 +279,15 @@ FormData.prototype._getContentDisposition = function (value, options) { // eslin
   }
 
   if (filename) {
+    // RFC 5987: If filename contains characters outside attr-char set,
+    // include both filename (for backwards compatibility) and filename* (RFC 5987 encoded)
+    // Per RFC 6266 Section 4.3, receivers should prefer filename* over filename
+    if (needsRfc5987Encoding(filename)) {
+      // Include both for maximum compatibility:
+      // - filename with quotes (legacy, some special chars may cause issues)
+      // - filename* with RFC 5987 encoding (modern, properly handles all chars)
+      return 'filename="' + filename.replace(/"/g, '\\"') + '"; filename*=utf-8\'\'' + rfc5987Encode(filename);
+    }
     return 'filename="' + filename + '"';
   }
 };

--- a/test/integration/test-get-buffer.js
+++ b/test/integration/test-get-buffer.js
@@ -43,3 +43,47 @@ var FormData = require(common.dir.lib + '/form_data');
   assert.equal(buffer.length, expected.length);
   assert.equal(buffer.toString('hex'), expected.toString('hex'));
 }());
+
+// RFC 5987: Test filename* encoding for special characters (issue #572)
+(function testRfc5987Encoding() {
+  var form = new FormData();
+
+  // Test with parentheses - characters that must be encoded per RFC 5987
+  form.append('file', Buffer.from('test content'), 'test(1).txt');
+
+  var buffer = form.getBuffer();
+  var content = buffer.toString();
+
+  // Should include both filename and filename* parameters
+  assert(content.includes('filename="test(1).txt"'), 'Should include basic filename');
+  assert(content.includes("filename*=utf-8''test%281%29.txt"), 'Should include RFC 5987 encoded filename*');
+}());
+
+// RFC 5987: Normal filenames should not include filename*
+(function testNoRfc5987ForNormal() {
+  var form = new FormData();
+
+  // Test with normal filename - no special characters
+  form.append('file', Buffer.from('test content'), 'normal.txt');
+
+  var buffer = form.getBuffer();
+  var content = buffer.toString();
+
+  // Should only include basic filename, not filename*
+  assert(content.includes('filename="normal.txt"'), 'Should include basic filename');
+  assert(!content.includes('filename*'), 'Should NOT include filename* for simple names');
+}());
+
+// RFC 5987: Test with spaces and unicode
+(function testRfc5987Spaces() {
+  var form = new FormData();
+
+  form.append('file', Buffer.from('test'), 'my document.pdf');
+
+  var buffer = form.getBuffer();
+  var content = buffer.toString();
+
+  // Space is not in attr-char, so should trigger encoding
+  assert(content.includes('filename="my document.pdf"'), 'Should include basic filename');
+  assert(content.includes("filename*=utf-8''my%20document.pdf"), 'Should encode space');
+}());


### PR DESCRIPTION
## Summary

- Filenames with special characters (parentheses, spaces, etc.) now include RFC 5987 encoded `filename*` parameter
- Normal filenames without special characters remain unchanged (backwards compatible)
- Fixes compatibility with .NET servers that strictly validate Content-Disposition headers

## Problem

When uploading files with parentheses in the filename (e.g., `test(1).txt`), .NET 8 servers reject the request with "Failed to read the request form. Form section has invalid Content-Disposition value".

Per RFC 2616 Section 2.2, parentheses are separators and should not appear unencoded in header parameter values. Per RFC 5987 Section 3.2.1, the `attr-char` set only includes:
```
ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
```

## Solution

When a filename contains characters outside the `attr-char` set, the fix now generates:
```
Content-Disposition: form-data; name="file"; filename="test(1).txt"; filename*=utf-8''test%281%29.txt
```

Per RFC 6266 Section 4.3, receivers should prefer `filename*` over `filename`, but including both ensures maximum compatibility.

For filenames without special characters, the output remains unchanged:
```
Content-Disposition: form-data; name="file"; filename="normal.txt"
```

## Test Plan

- [x] All existing tests pass (28 test files)
- [x] Added 3 new test cases for RFC 5987 encoding
- [x] Linting passes (warnings only)
- [x] Coverage maintained at 98%+

## Compatibility

- [x] No breaking changes for existing filenames
- [x] Backwards compatible - basic `filename` always included
- [x] Works with strict RFC-compliant servers (.NET, etc.)

Fixes #572