### PR TITLE
[Fix] escape CR and LF in the part Content-Type header

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -194,7 +194,9 @@ FormData.prototype._multiPartHeader = function (field, value, options) {
     // add custom disposition as third element or keep it two elements if not
     'Content-Disposition': ['form-data', 'name="' + escapeHeaderParam(field) + '"'].concat(contentDisposition || []),
     // if no content type. allow it to be empty array
-    'Content-Type': [].concat(contentType || [])
+    'Content-Type': [].concat(contentType || []).map(function (ct) {
+      return String(ct).replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+    })
   };
 
   // allow custom headers.

--- a/test/integration/test-header-injection.js
+++ b/test/integration/test-header-injection.js
@@ -51,3 +51,30 @@ var FormData = require(common.dir.lib + '/form_data');
 
   assert.notEqual(output.indexOf('name="items[0]"'), -1, 'a field name without control characters must be unchanged');
 }());
+
+(function testContentTypeCRLFInjection() {
+  var form = new FormData();
+  var boundary = form.getBoundary();
+
+  form.append('file', Buffer.from('x'), {
+    filename: 'photo.png',
+    contentType: 'image/png\r\n\r\nsmuggled\r\n--' + boundary + '\r\nContent-Disposition: form-data; name="is_admin"\r\n\r\ntrue\r\n--' + boundary + '\r\nContent-Disposition: form-data; name="fake'
+  });
+
+  var output = form.getBuffer().toString();
+  var headerLines = output.split('\r\n').filter(function (line) {
+    return line.indexOf('Content-Disposition') === 0;
+  });
+
+  assert.equal(headerLines.length, 1, 'a CRLF-laden content-type must stay on its own header line, smuggling no extra parts');
+  assert.notEqual(output.indexOf('image/png%0D%0A'), -1, 'CR/LF in a content-type must be escaped');
+}());
+
+(function testOrdinaryContentTypePreserved() {
+  var form = new FormData();
+  form.append('file', Buffer.from('x'), { filename: 'a.txt', contentType: 'text/plain; charset="utf-8"' });
+
+  var output = form.getBuffer().toString();
+
+  assert.notEqual(output.indexOf('Content-Type: text/plain; charset="utf-8"'), -1, 'a content-type without control characters must be unchanged');
+}());


### PR DESCRIPTION
### Summary

A part's `Content-Type` is taken from `options.contentType` and concatenated verbatim into the multipart header block, with no CR/LF escaping. A caller that forwards an attacker-controlled MIME type — e.g. an upload proxy that preserves the client's `Content-Type` header — lets an attacker embed CRLF to break out of the header line and smuggle extra headers or whole multipart parts (CWE-93).

This is the sibling of the field-name / filename injection fixed in [GHSA-hmw2-7cc7-3qxx](https://github.com/form-data/form-data/security/advisories/GHSA-hmw2-7cc7-3qxx) (`8dff42c`). That fix routed `field` and `filename` through `escapeHeaderParam`, but the `Content-Type` value at `lib/form_data.js:197` was left untouched.

### Reproduction

```js
const FormData = require('form-data');

const form = new FormData();
const boundary = form.getBoundary();

// attacker controls only the forwarded MIME type of an upload
const injected = 'image/png\r\n\r\nvalue_of_file\r\n'
  + '--' + boundary + '\r\nContent-Disposition: form-data; name="is_admin"\r\n\r\ntrue\r\n'
  + '--' + boundary + '\r\nContent-Disposition: form-data; name="filler"';

form.append('file', Buffer.from('REAL'), { filename: 'photo.png', contentType: injected });

const res = new Response(form.getBuffer(),
  { headers: { 'content-type': 'multipart/form-data; boundary=' + boundary } });
console.log([...(await res.formData()).keys()]);
// before: [ 'file', 'is_admin', 'filler' ]   <- is_admin=true smuggled
// after:  [ 'file' ]
```

The developer appended one field; a WHATWG-compliant parser (`undici` / `busboy` / `multer` / python-multipart) reads three, including an attacker-injected `is_admin=true`.

### Fix

Escape `\r` and `\n` as `%0D` and `%0A` on the `Content-Type` value, matching the WHATWG multipart/form-data encoding already used for `name`/`filename`.

Unlike a `name`/`filename` (a quoted-string parameter), a media type is **not** a quoted-string, so `"`, `;` and `=` are legitimate in it (e.g. `text/plain; charset="utf-8"`) and are deliberately left intact — only CR/LF can terminate the header line, so escaping just those closes the injection without corrupting valid content types. That's why this uses a CR/LF-only escape rather than reusing `escapeHeaderParam` (which also `%22`-escapes `"`).

### Tests

Extends `test/integration/test-header-injection.js`:
- `testContentTypeCRLFInjection` — a CRLF-laden content type stays on one header line and smuggles no extra part (fails before this change).
- `testOrdinaryContentTypePreserved` — a content type with a quoted `charset` parameter is emitted unchanged.

Full suite is green (`0 errors in 29 files`).
